### PR TITLE
Update array syntax to conform to RFC 520

### DIFF
--- a/src/crypto/auth_macros.rs
+++ b/src/crypto/auth_macros.rs
@@ -14,7 +14,7 @@ pub const TAGBYTES: uint = $tagbytes;
  * When a `Key` goes out of scope its contents
  * will be zeroed out
  */
-pub struct Key(pub [u8, ..KEYBYTES]);
+pub struct Key(pub [u8; KEYBYTES]);
 
 newtype_drop!(Key);
 newtype_clone!(Key);
@@ -27,7 +27,7 @@ newtype_impl!(Key, KEYBYTES);
   * comparison functions. See `sodiumoxide::crypto::verify::verify_32`
   */
 #[deriving(Copy)]
-pub struct Tag(pub [u8, ..TAGBYTES]);
+pub struct Tag(pub [u8; TAGBYTES]);
 
 impl Eq for Tag {}
 
@@ -49,7 +49,7 @@ newtype_impl!(Tag, TAGBYTES);
  * from sodiumoxide.
  */
 pub fn gen_key() -> Key {
-    let mut k = [0, ..KEYBYTES];
+    let mut k = [0; KEYBYTES];
     randombytes_into(&mut k);
     Key(k)
 }
@@ -61,7 +61,7 @@ pub fn gen_key() -> Key {
 pub fn authenticate(m: &[u8],
                     &Key(k): &Key) -> Tag {
     unsafe {
-        let mut tag = [0, ..TAGBYTES];
+        let mut tag = [0; TAGBYTES];
         $auth_name(tag.as_mut_ptr(),
                    m.as_ptr(),
                    m.len() as c_ulonglong,
@@ -122,7 +122,7 @@ mod bench {
     use randombytes::randombytes;
     use super::*;
 
-    const BENCH_SIZES: [uint, ..14] = [0, 1, 2, 4, 8, 16, 32, 64, 
+    const BENCH_SIZES: [uint; 14] = [0, 1, 2, 4, 8, 16, 32, 64,
                                        128, 256, 512, 1024, 2048, 4096];
 
     #[bench]

--- a/src/crypto/curve25519.rs
+++ b/src/crypto/curve25519.rs
@@ -15,7 +15,7 @@ pub const SCALARBYTES: uint = ffi::crypto_scalarmult_curve25519_SCALARBYTES as u
  * `Scalar` value (integer in byte representation)
  */
 #[deriving(Copy)]
-pub struct Scalar(pub [u8, ..SCALARBYTES]);
+pub struct Scalar(pub [u8; SCALARBYTES]);
 
 newtype_clone!(Scalar);
 newtype_impl!(Scalar, SCALARBYTES);
@@ -24,7 +24,7 @@ newtype_impl!(Scalar, SCALARBYTES);
  * `GroupElement`
  */
 #[deriving(Copy)]
-pub struct GroupElement(pub [u8, ..BYTES]);
+pub struct GroupElement(pub [u8; BYTES]);
 
 newtype_clone!(GroupElement);
 newtype_impl!(GroupElement, BYTES);
@@ -36,7 +36,7 @@ newtype_impl!(GroupElement, BYTES);
  */
 pub fn scalarmult(&Scalar(n): &Scalar,
                   &GroupElement(p): &GroupElement) -> GroupElement {
-    let mut q = [0, ..BYTES];
+    let mut q = [0; BYTES];
     unsafe {
         ffi::crypto_scalarmult_curve25519(q.as_mut_ptr(), n.as_ptr(), p.as_ptr());
     }
@@ -49,7 +49,7 @@ pub fn scalarmult(&Scalar(n): &Scalar,
  * group element `q`/
  */
 pub fn scalarmult_base(&Scalar(n): &Scalar) -> GroupElement {
-    let mut q = [0, ..BYTES];
+    let mut q = [0; BYTES];
     unsafe {
         ffi::crypto_scalarmult_curve25519_base(q.as_mut_ptr(), n.as_ptr());
     }
@@ -132,8 +132,8 @@ mod bench {
 
     #[bench]
     fn bench_scalarmult(b: &mut test::Bencher) {
-        let mut gbs = [0u8, ..BYTES];
-        let mut sbs = [0u8, ..SCALARBYTES];
+        let mut gbs = [0u8; BYTES];
+        let mut sbs = [0u8; SCALARBYTES];
         randombytes_into(&mut gbs);
         randombytes_into(&mut sbs);
         let g = GroupElement(gbs);
@@ -145,7 +145,7 @@ mod bench {
 
     #[bench]
     fn bench_scalarmult_base(b: &mut test::Bencher) {
-        let mut sbs = [0u8, ..SCALARBYTES];
+        let mut sbs = [0u8; SCALARBYTES];
         randombytes_into(&mut sbs);
         let s = Scalar(sbs);
         b.iter(|| {

--- a/src/crypto/curve25519xsalsa20poly1305.rs
+++ b/src/crypto/curve25519xsalsa20poly1305.rs
@@ -23,7 +23,7 @@ const BOXZEROBYTES: uint = ffi::crypto_box_curve25519xsalsa20poly1305_BOXZEROBYT
  * `PublicKey` for asymmetric authenticated encryption
  */
 #[deriving(Copy)]
-pub struct PublicKey(pub [u8, ..PUBLICKEYBYTES]);
+pub struct PublicKey(pub [u8; PUBLICKEYBYTES]);
 
 newtype_clone!(PublicKey);
 newtype_impl!(PublicKey, PUBLICKEYBYTES);
@@ -34,7 +34,7 @@ newtype_impl!(PublicKey, PUBLICKEYBYTES);
  * When a `SecretKey` goes out of scope its contents
  * will be zeroed out
  */
-pub struct SecretKey(pub [u8, ..SECRETKEYBYTES]);
+pub struct SecretKey(pub [u8; SECRETKEYBYTES]);
 
 newtype_drop!(SecretKey);
 newtype_clone!(SecretKey);
@@ -44,7 +44,7 @@ newtype_impl!(SecretKey, SECRETKEYBYTES);
  * `Nonce` for asymmetric authenticated encryption
  */
 #[deriving(Copy)]
-pub struct Nonce(pub [u8, ..NONCEBYTES]);
+pub struct Nonce(pub [u8; NONCEBYTES]);
 
 newtype_clone!(Nonce);
 newtype_impl!(Nonce, NONCEBYTES);
@@ -58,8 +58,8 @@ newtype_impl!(Nonce, NONCEBYTES);
  */
 pub fn gen_keypair() -> (PublicKey, SecretKey) {
     unsafe {
-        let mut pk = [0u8, ..PUBLICKEYBYTES];
-        let mut sk = [0u8, ..SECRETKEYBYTES];
+        let mut pk = [0u8; PUBLICKEYBYTES];
+        let mut sk = [0u8; SECRETKEYBYTES];
         ffi::crypto_box_curve25519xsalsa20poly1305_keypair(
             pk.as_mut_ptr(),
             sk.as_mut_ptr());
@@ -75,7 +75,7 @@ pub fn gen_keypair() -> (PublicKey, SecretKey) {
  * from sodiumoxide.
  */
 pub fn gen_nonce() -> Nonce {
-    let mut n = [0, ..NONCEBYTES];
+    let mut n = [0; NONCEBYTES];
     randombytes_into(&mut n);
     Nonce(n)
 }
@@ -138,7 +138,7 @@ pub fn open(c: &[u8],
  *
  * When a `PrecomputedKey` goes out of scope its contents will be zeroed out
  */
-pub struct PrecomputedKey([u8, ..PRECOMPUTEDKEYBYTES]);
+pub struct PrecomputedKey([u8; PRECOMPUTEDKEYBYTES]);
 
 newtype_drop!(PrecomputedKey);
 newtype_clone!(PrecomputedKey);
@@ -150,7 +150,7 @@ newtype_impl!(PrecomputedKey, PRECOMPUTEDKEYBYTES);
  */
 pub fn precompute(&PublicKey(pk): &PublicKey,
                   &SecretKey(sk): &SecretKey) -> PrecomputedKey {
-    let mut k = [0u8, ..PRECOMPUTEDKEYBYTES];
+    let mut k = [0u8; PRECOMPUTEDKEYBYTES];
     unsafe {
         ffi::crypto_box_curve25519xsalsa20poly1305_beforenm(k.as_mut_ptr(),
                                                        pk.as_ptr(),
@@ -396,7 +396,7 @@ mod bench {
     use randombytes::randombytes;
     use super::*;
 
-    const BENCH_SIZES: [uint, ..14] = [0, 1, 2, 4, 8, 16, 32, 64, 
+    const BENCH_SIZES: [uint; 14] = [0, 1, 2, 4, 8, 16, 32, 64,
                                        128, 256, 512, 1024, 2048, 4096];
 
     #[bench]

--- a/src/crypto/ed25519.rs
+++ b/src/crypto/ed25519.rs
@@ -25,7 +25,7 @@ pub const SIGNATUREBYTES: uint = ffi::crypto_sign_ed25519_BYTES as uint;
  * When a `Seed` goes out of scope its contents
  * will be zeroed out
  */
-pub struct Seed(pub [u8, ..SEEDBYTES]);
+pub struct Seed(pub [u8; SEEDBYTES]);
 
 newtype_drop!(Seed);
 newtype_clone!(Seed);
@@ -37,7 +37,7 @@ newtype_impl!(Seed, SEEDBYTES);
  * When a `SecretKey` goes out of scope its contents
  * will be zeroed out
  */
-pub struct SecretKey(pub [u8, ..SECRETKEYBYTES]);
+pub struct SecretKey(pub [u8; SECRETKEYBYTES]);
 
 newtype_drop!(SecretKey);
 newtype_clone!(SecretKey);
@@ -47,7 +47,7 @@ newtype_impl!(SecretKey, SECRETKEYBYTES);
  * `PublicKey` for signatures
  */
 #[deriving(Copy)]
-pub struct PublicKey(pub [u8, ..PUBLICKEYBYTES]);
+pub struct PublicKey(pub [u8; PUBLICKEYBYTES]);
 
 newtype_clone!(PublicKey);
 newtype_impl!(PublicKey, PUBLICKEYBYTES);
@@ -62,8 +62,8 @@ newtype_impl!(PublicKey, PUBLICKEYBYTES);
  */
 pub fn gen_keypair() -> (PublicKey, SecretKey) {
     unsafe {
-        let mut pk = [0u8, ..PUBLICKEYBYTES];
-        let mut sk = [0u8, ..SECRETKEYBYTES];
+        let mut pk = [0u8; PUBLICKEYBYTES];
+        let mut sk = [0u8; SECRETKEYBYTES];
         ffi::crypto_sign_ed25519_keypair(pk.as_mut_ptr(), sk.as_mut_ptr());
         (PublicKey(pk), SecretKey(sk))
     }
@@ -75,8 +75,8 @@ pub fn gen_keypair() -> (PublicKey, SecretKey) {
  */
 pub fn keypair_from_seed(&Seed(seed): &Seed) -> (PublicKey, SecretKey) {
     unsafe {
-        let mut pk = [0u8, ..PUBLICKEYBYTES];
-        let mut sk = [0u8, ..SECRETKEYBYTES];
+        let mut pk = [0u8; PUBLICKEYBYTES];
+        let mut sk = [0u8; SECRETKEYBYTES];
         ffi::crypto_sign_ed25519_seed_keypair(pk.as_mut_ptr(),
                                          sk.as_mut_ptr(),
                                          seed.as_ptr());
@@ -158,7 +158,7 @@ fn test_sign_verify_tamper() {
 fn test_sign_verify_seed() {
     use randombytes::{randombytes, randombytes_into};
     for i in range(0, 256u) {
-        let mut seedbuf = [0, ..32];
+        let mut seedbuf = [0; 32];
         randombytes_into(&mut seedbuf);
         let seed = Seed(seedbuf);
         let (pk, sk) = keypair_from_seed(&seed);
@@ -173,7 +173,7 @@ fn test_sign_verify_seed() {
 fn test_sign_verify_tamper_seed() {
     use randombytes::{randombytes, randombytes_into};
     for i in range(0, 32u) {
-        let mut seedbuf = [0, ..32];
+        let mut seedbuf = [0; 32];
         randombytes_into(&mut seedbuf);
         let seed = Seed(seedbuf);
         let (pk, sk) = keypair_from_seed(&seed);
@@ -211,7 +211,7 @@ fn test_vectors() {
         let x3 = x.next().unwrap();
         let seed_bytes = x0.slice(0, 64).from_hex().unwrap();
         assert!(seed_bytes.len() == SEEDBYTES);
-        let mut seedbuf = [0u8, ..SEEDBYTES];
+        let mut seedbuf = [0u8; SEEDBYTES];
         for (s, b) in seedbuf.iter_mut().zip(seed_bytes.iter()) {
             *s = *b
         }
@@ -232,7 +232,7 @@ mod bench {
     use randombytes::randombytes;
     use super::*;
 
-    const BENCH_SIZES: [uint, ..14] = [0, 1, 2, 4, 8, 16, 32, 64,
+    const BENCH_SIZES: [uint; 14] = [0, 1, 2, 4, 8, 16, 32, 64,
                                        128, 256, 512, 1024, 2048, 4096];
 
     #[bench]

--- a/src/crypto/edwards25519sha512batch.rs
+++ b/src/crypto/edwards25519sha512batch.rs
@@ -16,7 +16,7 @@ pub const SIGNATUREBYTES: uint = ffi::crypto_sign_edwards25519sha512batch_BYTES 
  * When a `SecretKey` goes out of scope its contents
  * will be zeroed out
  */
-pub struct SecretKey(pub [u8, ..SECRETKEYBYTES]);
+pub struct SecretKey(pub [u8; SECRETKEYBYTES]);
 
 newtype_drop!(SecretKey);
 newtype_clone!(SecretKey);
@@ -26,7 +26,7 @@ newtype_impl!(SecretKey, SECRETKEYBYTES);
  * `PublicKey` for signatures
  */
 #[deriving(Copy)]
-pub struct PublicKey(pub [u8, ..PUBLICKEYBYTES]);
+pub struct PublicKey(pub [u8; PUBLICKEYBYTES]);
 
 newtype_clone!(PublicKey);
 newtype_impl!(PublicKey, PUBLICKEYBYTES);
@@ -41,8 +41,8 @@ newtype_impl!(PublicKey, PUBLICKEYBYTES);
  */
 pub fn gen_keypair() -> (PublicKey, SecretKey) {
     unsafe {
-        let mut pk = [0u8, ..PUBLICKEYBYTES];
-        let mut sk = [0u8, ..SECRETKEYBYTES];
+        let mut pk = [0u8; PUBLICKEYBYTES];
+        let mut sk = [0u8; SECRETKEYBYTES];
         ffi::crypto_sign_edwards25519sha512batch_keypair(pk.as_mut_ptr(),
                                                     sk.as_mut_ptr());
         (PublicKey(pk), SecretKey(sk))
@@ -125,7 +125,7 @@ mod bench {
     use randombytes::randombytes;
     use super::*;
 
-    const BENCH_SIZES: [uint, ..14] = [0, 1, 2, 4, 8, 16, 32, 64,
+    const BENCH_SIZES: [uint; 14] = [0, 1, 2, 4, 8, 16, 32, 64,
                                        128, 256, 512, 1024, 2048, 4096];
 
     #[bench]

--- a/src/crypto/hash_macros.rs
+++ b/src/crypto/hash_macros.rs
@@ -8,7 +8,7 @@ pub const BLOCKBYTES: uint = $blockbytes;
  * Digest-structure
  */
 #[deriving(Copy)]
-pub struct Digest(pub [u8, ..HASHBYTES]);
+pub struct Digest(pub [u8; HASHBYTES]);
 
 newtype_clone!(Digest);
 newtype_impl!(Digest, HASHBYTES);
@@ -18,7 +18,7 @@ newtype_impl!(Digest, HASHBYTES);
  */
 pub fn hash(m: &[u8]) -> Digest {
     unsafe {
-        let mut h = [0, ..HASHBYTES];
+        let mut h = [0; HASHBYTES];
         $hash_name(h.as_mut_ptr(), m.as_ptr(), m.len() as c_ulonglong);
         Digest(h)
     }
@@ -30,7 +30,7 @@ mod bench {
     use randombytes::randombytes;
     use super::*;
 
-    const BENCH_SIZES: [uint, ..14] = [0, 1, 2, 4, 8, 16, 32, 64,
+    const BENCH_SIZES: [uint; 14] = [0, 1, 2, 4, 8, 16, 32, 64,
                                        128, 256, 512, 1024, 2048, 4096];
 
     #[bench]

--- a/src/crypto/siphash24.rs
+++ b/src/crypto/siphash24.rs
@@ -14,7 +14,7 @@ pub const KEYBYTES: uint = ffi::crypto_shorthash_siphash24_KEYBYTES as uint;
  * Digest-structure
  */
 #[deriving(Copy)]
-pub struct Digest(pub [u8, ..HASHBYTES]);
+pub struct Digest(pub [u8; HASHBYTES]);
 
 newtype_clone!(Digest);
 newtype_impl!(Digest, HASHBYTES);
@@ -25,7 +25,7 @@ newtype_impl!(Digest, HASHBYTES);
  * When a `Key` goes out of scope its contents
  * will be zeroed out
  */
-pub struct Key(pub [u8, ..KEYBYTES]);
+pub struct Key(pub [u8; KEYBYTES]);
 
 newtype_drop!(Key);
 newtype_clone!(Key);
@@ -39,7 +39,7 @@ newtype_impl!(Key, KEYBYTES);
  * from sodiumoxide.
  */
 pub fn gen_key() -> Key {
-    let mut k = [0, ..KEYBYTES];
+    let mut k = [0; KEYBYTES];
     randombytes_into(&mut k);
     Key(k)
 }
@@ -51,7 +51,7 @@ pub fn gen_key() -> Key {
 pub fn shorthash(m: &[u8],
                  &Key(k): &Key) -> Digest {
     unsafe {
-        let mut h = [0, ..HASHBYTES];
+        let mut h = [0; HASHBYTES];
         ffi::crypto_shorthash_siphash24(h.as_mut_ptr(),
                                    m.as_ptr(), m.len() as c_ulonglong,
                                    k.as_ptr());
@@ -143,7 +143,7 @@ mod bench {
     use randombytes::randombytes;
     use super::*;
 
-    const BENCH_SIZES: [uint, ..14] = [0, 1, 2, 4, 8, 16, 32, 64,
+    const BENCH_SIZES: [uint; 14] = [0, 1, 2, 4, 8, 16, 32, 64,
                                        128, 256, 512, 1024, 2048, 4096];
 
     #[bench]

--- a/src/crypto/stream_macros.rs
+++ b/src/crypto/stream_macros.rs
@@ -1,7 +1,7 @@
 #![macro_escape]
-macro_rules! stream_module (($stream_name:ident, 
-                             $xor_name:ident, 
-                             $keybytes:expr, 
+macro_rules! stream_module (($stream_name:ident,
+                             $xor_name:ident,
+                             $keybytes:expr,
                              $noncebytes:expr) => (
 
 pub const KEYBYTES: uint = $keybytes;
@@ -13,7 +13,7 @@ pub const NONCEBYTES: uint = $noncebytes;
  * When a `Key` goes out of scope its contents
  * will be zeroed out
  */
-pub struct Key(pub [u8, ..KEYBYTES]);
+pub struct Key(pub [u8; KEYBYTES]);
 
 newtype_drop!(Key);
 newtype_clone!(Key);
@@ -23,7 +23,7 @@ newtype_impl!(Key, KEYBYTES);
  * `Nonce` for symmetric encryption
  */
 #[deriving(Copy)]
-pub struct Nonce(pub [u8, ..NONCEBYTES]);
+pub struct Nonce(pub [u8; NONCEBYTES]);
 
 newtype_clone!(Nonce);
 newtype_impl!(Nonce, NONCEBYTES);
@@ -36,7 +36,7 @@ newtype_impl!(Nonce, NONCEBYTES);
  * from sodiumoxide.
  */
 pub fn gen_key() -> Key {
-    let mut key = [0, ..KEYBYTES];
+    let mut key = [0; KEYBYTES];
     randombytes_into(&mut key);
     Key(key)
 }
@@ -52,7 +52,7 @@ pub fn gen_key() -> Key {
  * do not use random nonces since the probability of nonce-collision is not negligible
  */
 pub fn gen_nonce() -> Nonce {
-    let mut nonce = [0, ..NONCEBYTES];
+    let mut nonce = [0; NONCEBYTES];
     randombytes_into(&mut nonce);
     Nonce(nonce)
 }
@@ -168,7 +168,7 @@ mod bench {
     extern crate test;
     use super::*;
 
-    const BENCH_SIZES: [uint, ..14] = [0, 1, 2, 4, 8, 16, 32, 64, 
+    const BENCH_SIZES: [uint; 14] = [0, 1, 2, 4, 8, 16, 32, 64,
                                        128, 256, 512, 1024, 2048, 4096];
 
     #[bench]

--- a/src/crypto/verify.rs
+++ b/src/crypto/verify.rs
@@ -15,7 +15,7 @@ use ffi;
  * that depends on the longest matching prefix of `x` and `y`, often allowing easy
  * timing attacks.
  */
-pub fn verify_16(x: &[u8, ..16], y: &[u8, ..16]) -> bool {
+pub fn verify_16(x: &[u8; 16], y: &[u8; 16]) -> bool {
     unsafe {
         ffi::crypto_verify_16(x.as_ptr(), y.as_ptr()) == 0
     }
@@ -32,7 +32,7 @@ pub fn verify_16(x: &[u8, ..16], y: &[u8, ..16]) -> bool {
  * that depends on the longest matching prefix of `x` and `y`, often allowing easy
  * timing attacks.
  */
-pub fn verify_32(x: &[u8, ..32], y: &[u8, ..32]) -> bool {
+pub fn verify_32(x: &[u8; 32], y: &[u8; 32]) -> bool {
     unsafe {
         ffi::crypto_verify_32(x.as_ptr(), y.as_ptr()) == 0
     }
@@ -43,8 +43,8 @@ fn test_verify_16() {
     use randombytes::randombytes_into;
 
     for _ in range(0u, 256) {
-        let mut x = [0, ..16];
-        let mut y = [0, ..16];
+        let mut x = [0; 16];
+        let mut y = [0; 16];
         assert!(verify_16(&x, &y));
         randombytes_into(&mut x);
         randombytes_into(&mut y);
@@ -61,8 +61,8 @@ fn test_verify_32() {
     use randombytes::randombytes_into;
 
     for _ in range(0u, 256) {
-        let mut x = [0, ..32];
-        let mut y = [0, ..32];
+        let mut x = [0; 32];
+        let mut y = [0; 32];
         assert!(verify_32(&x, &y));
         randombytes_into(&mut x);
         randombytes_into(&mut y);

--- a/src/crypto/xsalsa20poly1305.rs
+++ b/src/crypto/xsalsa20poly1305.rs
@@ -20,7 +20,7 @@ pub const NONCEBYTES: uint = ffi::crypto_secretbox_xsalsa20poly1305_NONCEBYTES a
  * When a `Key` goes out of scope its contents
  * will be zeroed out
  */
-pub struct Key(pub [u8, ..KEYBYTES]);
+pub struct Key(pub [u8; KEYBYTES]);
 
 newtype_drop!(Key);
 newtype_clone!(Key);
@@ -30,7 +30,7 @@ newtype_impl!(Key, KEYBYTES);
  * `Nonce` for symmetric authenticated encryption
  */
 #[deriving(Copy)]
-pub struct Nonce(pub [u8, ..NONCEBYTES]);
+pub struct Nonce(pub [u8; NONCEBYTES]);
 
 newtype_clone!(Nonce);
 newtype_impl!(Nonce, NONCEBYTES);
@@ -46,7 +46,7 @@ const BOXZEROBYTES: uint = 16;
  * from sodiumoxide.
  */
 pub fn gen_key() -> Key {
-    let mut key = [0, ..KEYBYTES];
+    let mut key = [0; KEYBYTES];
     randombytes_into(&mut key);
     Key(key)
 }
@@ -59,7 +59,7 @@ pub fn gen_key() -> Key {
  * from sodiumoxide.
  */
 pub fn gen_nonce() -> Nonce {
-    let mut nonce = [0, ..NONCEBYTES];
+    let mut nonce = [0; NONCEBYTES];
     randombytes_into(&mut nonce);
     Nonce(nonce)
 }
@@ -194,7 +194,7 @@ mod bench {
     use randombytes::randombytes;
     use super::*;
 
-    const BENCH_SIZES: [uint, ..14] = [0, 1, 2, 4, 8, 16, 32, 64, 
+    const BENCH_SIZES: [uint; 14] = [0, 1, 2, 4, 8, 16, 32, 64,
                                        128, 256, 512, 1024, 2048, 4096];
 
     #[bench]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,7 +52,7 @@ macro_rules! newtype_impl (($newtype:ident, $len:expr) => (
             if bs.len() != $len {
                 return None
             }
-            let mut n = $newtype([0, ..$len]);
+            let mut n = $newtype([0; $len]);
             {
                 let $newtype(ref mut b) = n;
                 for (bi, &bsi) in b.iter_mut().zip(bs.iter()) {


### PR DESCRIPTION
I updated to `0.13.0-nightly (fc2ba1393 2015-01-03 05:35:17 +0000)` and noticed that sodiumoxide's build started to fail. This PR fixes the build process with the latest nightly, however it's not backwards compatible.