### PR TITLE
Enable static linking support (similar to openssl-sys)

### DIFF
--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -1,3 +1,15 @@
+use std::env;
+
 fn main () {
-    println!("cargo:rustc-flags=-l sodium");
+    if let Some(lib_dir) = env::var("SODIUM_LIB_DIR").ok() {
+    	println!("cargo:rustc-flags=-L native={}", lib_dir);
+    }
+
+    let mode = if env::var_os("SODIUM_STATIC").is_some() {
+    	"static"
+    } else {
+    	"dylib"
+    };
+
+    println!("cargo:rustc-flags=-l {0}=sodium", mode);
 }


### PR DESCRIPTION
Add support for statically linking libsodium similar to https://github.com/sfackler/rust-openssl#manual-configuration

```
export SODIUM_LIB_DIR=/usr/local/lib/
export SODIUM_STATIC=true
```