### PR TITLE
Implement PartialEq and Eq for crypto::sign::PublicKey

### DIFF
--- a/src/crypto/sign/ed25519.rs
+++ b/src/crypto/sign/ed25519.rs
@@ -37,7 +37,7 @@ newtype_clone!(SecretKey);
 newtype_impl!(SecretKey, SECRETKEYBYTES);
 
 /// `PublicKey` for signatures
-#[derive(Copy)]
+#[derive(PartialEq, Eq, Copy)]
 pub struct PublicKey(pub [u8; PUBLICKEYBYTES]);
 
 newtype_clone!(PublicKey);


### PR DESCRIPTION
For use in MaidSafe's Sentinel library we need to search for crypto::sign::PublicKeys in a collection.  Please consider this patch to implement PartialEq and Eq for public signing keys.

Signed-off-by: Benjamin Bollen <benjamin.bollen@maidsafe.net>