### PR TITLE
Zero scalars when dropped

### DIFF
--- a/src/crypto/scalarmult/curve25519.rs
+++ b/src/crypto/scalarmult/curve25519.rs
@@ -12,6 +12,7 @@ pub const SCALARBYTES: usize = ffi::crypto_scalarmult_curve25519_SCALARBYTES;
 #[derive(Copy)]
 pub struct Scalar(pub [u8; SCALARBYTES]);
 
+newtype_drop!(Scalar);
 newtype_clone!(Scalar);
 newtype_impl!(Scalar, SCALARBYTES);
 


### PR DESCRIPTION
Afaik scalars are always sensitive information, even in uncommon uses,
so they should be erased when dropped.