### PR TITLE
Zero scalars when dropped

### DIFF
--- a/src/crypto/scalarmult/curve25519.rs
+++ b/src/crypto/scalarmult/curve25519.rs
@@ -9,7 +9,6 @@ pub const BYTES: usize = ffi::crypto_scalarmult_curve25519_BYTES;
 pub const SCALARBYTES: usize = ffi::crypto_scalarmult_curve25519_SCALARBYTES;
 
 /// `Scalar` value (integer in byte representation)
-#[derive(Copy)]
 pub struct Scalar(pub [u8; SCALARBYTES]);
 
 newtype_drop!(Scalar);

--- a/src/crypto/scalarmult/curve25519.rs
+++ b/src/crypto/scalarmult/curve25519.rs
@@ -12,6 +12,7 @@ pub const SCALARBYTES: usize = ffi::crypto_scalarmult_curve25519_SCALARBYTES;
 #[derive(Copy)]
 pub struct Scalar(pub [u8; SCALARBYTES]);
 
+newtype_drop!(Scalar);
 newtype_clone!(Scalar);
 newtype_impl!(Scalar, SCALARBYTES);
 


### PR DESCRIPTION
Afaik scalars are always sensitive information, even in uncommon uses, so they should be erased when dropped. 

We cannot derive a Copy trait when we define a drop method, not even using `impl Copy for Scalar { }` directly, so we stop deriving Copy too. 