### PR TITLE
Fix derive_key() return type in docs

### DIFF
--- a/src/crypto/pwhash/scryptsalsa208sha256.rs
+++ b/src/crypto/pwhash/scryptsalsa208sha256.rs
@@ -88,7 +88,7 @@ pub fn gen_salt() -> Salt {
 /// the same salt, and the same values for opslimit and memlimit have to be
 /// used.
 ///
-/// The function returns `Some(key)` on success and `None` if the computation didn't
+/// The function returns `Some(())` on success and `None` if the computation didn't
 /// complete, usually because the operating system refused to allocate the
 /// amount of requested memory.
 pub fn derive_key(key: &mut [u8], passwd: &[u8], &Salt(ref sb): &Salt,


### PR DESCRIPTION
The documentation states that pwhash::derive_key() returns an
Option<Key>, but it actually returns Option<()>. This commit fixes
the inconsistency by correcting the docs.