### PR TITLE
sodium_memcmp() expects a size_t

### DIFF
--- a/src/crypto/verify.rs
+++ b/src/crypto/verify.rs
@@ -1,5 +1,6 @@
 //! Constant-time comparison of fixed-size vecs
 use ffi;
+use libc::size_t;
 
 /// `verify_16()` returns `true` if `x[0]`, `x[1]`, ..., `x[15]` are the
 /// same as `y[0]`, `y[1]`, ..., `y[15]`. Otherwise it returns `false`.
@@ -60,7 +61,7 @@ pub fn safe_memcmp(x: &[u8], y: &[u8]) -> bool {
         return false
     }
     unsafe {
-        ffi::sodium_memcmp(x.as_ptr(), y.as_ptr(), x.len() as u64) == 0
+        ffi::sodium_memcmp(x.as_ptr(), y.as_ptr(), x.len() as size_t) == 0
     }
 }
 


### PR DESCRIPTION
Since [sodium_memcmp expects a size_t as the length](https://github.com/dnaq/sodiumoxide/blob/6ab8f7cf501288237f999c7a1ef79c0931d8cc96/libsodium-sys/src/utils.rs#L5), when building on (or cross-compiling for) 32-bit architectures where `size_t` is a `u32`, enforcing a `u64` via `as u64` in `safe_memcmp` causes the code to not compile.