### PR TITLE
Increased libsodium version in Travis script to 1.0.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: rust
 install:
-- wget https://github.com/jedisct1/libsodium/releases/download/1.0.3/libsodium-1.0.3.tar.gz
-- tar xvfz libsodium-1.0.3.tar.gz
-- cd libsodium-1.0.3 && ./configure --prefix=/usr && make && sudo make install &&
+- wget https://github.com/jedisct1/libsodium/releases/download/1.0.6/libsodium-1.0.6.tar.gz
+- tar xvfz libsodium-1.0.6.tar.gz
+- cd libsodium-1.0.6 && ./configure --prefix=/usr && make && sudo make install &&
   cd ..
 script:
 - cargo build --verbose


### PR DESCRIPTION
When linking to libsodium 1.0.3, we get the following error:

>     undefined reference to `sodium_increment'

Version 1.0.4 links OK.

I'm not sure if you want to document 1.0.4 as a minimum requirement anywhere (e.g. the README) or even if we can check for this in build.rs?

I would have changed the dependency in the Travis script to the latest version (1.0.7) but this fails to link for me when using the prebuilt MinGW libraries.  I haven't assessed this issue yet, but my initial suspicions are that the prebuilt libs are defective since they're significantly smaller than those in 1.0.6, and libsodium's changelog doesn't indicate any significant reduction of its API.