### PR TITLE
Serialize as feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
 script:
 - cargo build --verbose
 - cargo test --verbose
+- cargo test --verbose --no-default-features
 - cargo doc
 after_script:
 - cd target/doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,11 @@ version = "0.0.9"
 [dependencies]
 libc = "0.2.1"
 libsodium-sys = "0.0.9"
+rustc-serialize = { version = "0.3.16", optional = true }
+
+[dev-dependencies]
 rustc-serialize = "0.3.16"
 
 [features]
 benchmarks = []
+default = ["rustc-serialize"]

--- a/src/crypto/auth/auth_macros.rs
+++ b/src/crypto/auth/auth_macros.rs
@@ -5,6 +5,7 @@ macro_rules! auth_module (($auth_name:ident,
 
 use libc::c_ulonglong;
 use randombytes::randombytes_into;
+#[cfg(feature = "default")]
 use rustc_serialize;
 
 /// Number of bytes in a `Key`.
@@ -69,7 +70,6 @@ pub fn verify(&Tag(ref tag): &Tag, m: &[u8],
 #[cfg(test)]
 mod test_m {
     use super::*;
-    use test_utils::round_trip;
 
     #[test]
     fn test_auth_verify() {
@@ -102,9 +102,11 @@ mod test_m {
         }
     }
 
+    #[cfg(feature = "default")]
     #[test]
     fn test_serialisation() {
         use randombytes::randombytes;
+        use test_utils::round_trip;
         for i in (0..256usize) {
             let k = gen_key();
             let m = randombytes(i);

--- a/src/crypto/box_/curve25519xsalsa20poly1305.rs
+++ b/src/crypto/box_/curve25519xsalsa20poly1305.rs
@@ -7,6 +7,7 @@
 use ffi;
 use marshal::marshal;
 use randombytes::randombytes_into;
+#[cfg(feature = "default")]
 use rustc_serialize;
 
 /// Number of bytes in a `PublicKey`.
@@ -183,7 +184,6 @@ pub fn open_precomputed(c: &[u8],
 #[cfg(test)]
 mod test {
     use super::*;
-    use test_utils::round_trip;
 
     #[test]
     fn test_seal_open() {
@@ -368,8 +368,10 @@ mod test {
         assert!(m_pre == mexp);
     }
 
+    #[cfg(feature = "default")]
     #[test]
     fn test_serialisation() {
+        use test_utils::round_trip;
         for _ in (0..256usize) {
             let (pk, sk) = gen_keypair();
             let n = gen_nonce();

--- a/src/crypto/hash/hash_macros.rs
+++ b/src/crypto/hash/hash_macros.rs
@@ -1,6 +1,7 @@
 macro_rules! hash_module (($hash_name:ident, $hashbytes:expr, $blockbytes:expr) => (
 
 use libc::c_ulonglong;
+#[cfg(feature = "default")]
 use rustc_serialize;
 
 /// Number of bytes in a `Digest`.
@@ -23,6 +24,7 @@ pub fn hash(m: &[u8]) -> Digest {
     }
 }
 
+#[cfg(feature = "default")]
 #[cfg(test)]
 mod test_encode {
     use super::*;

--- a/src/crypto/pwhash/scryptsalsa208sha256.rs
+++ b/src/crypto/pwhash/scryptsalsa208sha256.rs
@@ -3,6 +3,7 @@
 use ffi;
 use randombytes::randombytes_into;
 use libc::c_ulonglong;
+#[cfg(feature = "default")]
 use rustc_serialize;
 
 /// Number of bytes in a `Salt`.
@@ -168,7 +169,6 @@ pub fn pwhash_verify(&HashedPassword(ref str_): &HashedPassword,
 #[cfg(test)]
 mod test {
     use super::*;
-    use test_utils::round_trip;
 
     #[test]
     fn test_derive_key() {
@@ -210,9 +210,11 @@ mod test {
         }
     }
 
+    #[cfg(feature = "default")]
     #[test]
     fn test_serialisation() {
         use randombytes::randombytes;
+        use test_utils::round_trip;
         for i in (0..32usize) {
             let pw = randombytes(i);
             let pwh = pwhash(&pw, OPSLIMIT_INTERACTIVE, MEMLIMIT_INTERACTIVE).unwrap();

--- a/src/crypto/scalarmult/curve25519.rs
+++ b/src/crypto/scalarmult/curve25519.rs
@@ -11,6 +11,7 @@ pub const GROUPELEMENTBYTES: usize = ffi::crypto_scalarmult_curve25519_BYTES;
 /// Number of bytes in a `Scalar`.
 pub const SCALARBYTES: usize = ffi::crypto_scalarmult_curve25519_SCALARBYTES;
 
+#[cfg(feature = "default")]
 use rustc_serialize;
 
 new_type! {

--- a/src/crypto/secretbox/xsalsa20poly1305.rs
+++ b/src/crypto/secretbox/xsalsa20poly1305.rs
@@ -7,6 +7,7 @@
 use ffi;
 use marshal::marshal;
 use randombytes::randombytes_into;
+#[cfg(feature = "default")]
 use rustc_serialize;
 
 /// Number of bytes in `Key`.
@@ -95,7 +96,6 @@ pub fn open(c: &[u8],
 #[cfg(test)]
 mod test {
     use super::*;
-    use test_utils::round_trip;
 
     #[test]
     fn test_seal_open() {
@@ -178,8 +178,10 @@ mod test {
         assert!(Ok(m) == m2);
     }
 
+    #[cfg(feature = "default")]
     #[test]
     fn test_serialisation() {
+        use test_utils::round_trip;
         for _ in (0..256usize) {
             let k = gen_key();
             let n = gen_nonce();

--- a/src/crypto/shorthash/siphash24.rs
+++ b/src/crypto/shorthash/siphash24.rs
@@ -2,6 +2,7 @@
 use ffi;
 use libc::c_ulonglong;
 use randombytes::randombytes_into;
+#[cfg(feature = "default")]
 use rustc_serialize;
 
 /// Number of bytes in a `Digest`.
@@ -49,7 +50,6 @@ pub fn shorthash(m: &[u8],
 #[cfg(test)]
 mod test {
     use super::*;
-    use test_utils::round_trip;
 
     #[test]
     fn test_vectors() {
@@ -129,9 +129,11 @@ mod test {
         }
     }
 
+    #[cfg(feature = "default")]
     #[test]
     fn test_serialisation() {
         use randombytes::randombytes;
+        use test_utils::round_trip;
         for i in (0..64usize) {
             let k = gen_key();
             let m = randombytes(i);

--- a/src/crypto/sign/ed25519.rs
+++ b/src/crypto/sign/ed25519.rs
@@ -5,6 +5,7 @@
 use ffi;
 use libc::c_ulonglong;
 use std::iter::repeat;
+#[cfg(feature = "default")]
 use rustc_serialize;
 
 /// Number of bytes in a `Seed`.
@@ -148,7 +149,6 @@ pub fn verify_detached(&Signature(ref sig): &Signature,
 #[cfg(test)]
 mod test {
     use super::*;
-    use test_utils::round_trip;
 
     #[test]
     fn test_sign_verify() {
@@ -301,9 +301,11 @@ mod test {
         }
     }
 
+    #[cfg(feature = "default")]
     #[test]
     fn test_serialisation() {
         use randombytes::randombytes;
+        use test_utils::round_trip;
         for i in (0..256usize) {
             let (pk, sk) = gen_keypair();
             let m = randombytes(i);

--- a/src/crypto/sign/edwards25519sha512batch.rs
+++ b/src/crypto/sign/edwards25519sha512batch.rs
@@ -3,6 +3,7 @@
 use ffi;
 use libc::c_ulonglong;
 use std::iter::repeat;
+#[cfg(feature = "default")]
 use rustc_serialize;
 
 /// Number of bytes in a `SecretKey`.

--- a/src/crypto/stream/stream_macros.rs
+++ b/src/crypto/stream/stream_macros.rs
@@ -6,6 +6,7 @@ macro_rules! stream_module (($stream_name:ident,
 use libc::c_ulonglong;
 use std::iter::repeat;
 use randombytes::randombytes_into;
+#[cfg(feature = "default")]
 use rustc_serialize;
 
 /// Number of bytes in a `Key`.
@@ -108,7 +109,6 @@ pub fn stream_xor_inplace(m: &mut [u8],
 #[cfg(test)]
 mod test_m {
     use super::*;
-    use test_utils::round_trip;
 
     #[test]
     fn test_encrypt_decrypt() {
@@ -157,8 +157,10 @@ mod test_m {
         }
     }
 
+    #[cfg(feature = "default")]
     #[test]
     fn test_serialisation() {
+        use test_utils::round_trip;
         for _ in (0..1024usize) {
             let k = gen_key();
             let n = gen_nonce();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@
 
 extern crate libsodium_sys as ffi;
 extern crate libc;
+#[cfg(any(test, feature = "default"))]
 extern crate rustc_serialize;
 
 /// `init()` initializes the sodium library and chooses faster versions of

--- a/src/newtype_macros.rs
+++ b/src/newtype_macros.rs
@@ -37,6 +37,7 @@ macro_rules! newtype_traits (($newtype:ident, $len:expr) => (
         }
     }
     impl ::std::cmp::Eq for $newtype {}
+    #[cfg(feature = "default")]
     impl rustc_serialize::Encodable for $newtype {
         fn encode<E: rustc_serialize::Encoder>(&self, encoder: &mut E)
                 -> Result<(), E::Error> {
@@ -48,6 +49,7 @@ macro_rules! newtype_traits (($newtype:ident, $len:expr) => (
             })
         }
     }
+    #[cfg(feature = "default")]
     impl rustc_serialize::Decodable for $newtype {
         fn decode<D: rustc_serialize::Decoder>(decoder: &mut D)
                 -> Result<$newtype, D::Error> {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+#![cfg(all(test, feature = "default"))]
 
 use rustc_serialize::{Decodable, Encodable, json};
 


### PR DESCRIPTION
This PR makes rustc-serialize a dependency only for default builds and for the tests as discussed in https://github.com/dnaq/sodiumoxide/pull/75#issuecomment-119346122.

To avoid the dependency, we just need to pass `--no-default-features` to cargo.  I've added that as an additional line to the Travis script, so now most of the tests run twice, but I feel that's worthwhile to avoid accidentally breaking non-default builds of the library.

It might be worth adding some documentation to explain the feature and its use, either to the README or the generated crate docs or both.  For users of the lib, I believe they'd need to add something like the following to their Cargo.toml:
```
[dependencies.sodiumoxide]
version = "0.0.9"
default-features = false
```

If you want me to add the documentation, just let me know where and I can update this PR.