### PR TITLE
Used call_once in init() to make it thread-safe and updated documentation.

### DIFF
--- a/src/crypto/auth/auth_macros.rs
+++ b/src/crypto/auth/auth_macros.rs
@@ -31,9 +31,9 @@ new_type! {
 
 /// `gen_key()` randomly generates a key for authentication
 ///
-/// THREAD SAFETY: `gen_key()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
+/// THREAD SAFETY: `gen_key()` is thread-safe provided
+/// [`sodiumoxide::init()`](../../../fn.init.html) has been called and has returned
+/// `true` before using any other function from sodiumoxide.
 pub fn gen_key() -> Key {
     let mut k = [0; KEYBYTES];
     randombytes_into(&mut k);

--- a/src/crypto/box_/curve25519xsalsa20poly1305.rs
+++ b/src/crypto/box_/curve25519xsalsa20poly1305.rs
@@ -44,9 +44,9 @@ new_type! {
 
 /// `gen_keypair()` randomly generates a secret key and a corresponding public key.
 ///
-/// THREAD SAFETY: `gen_keypair()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
+/// THREAD SAFETY: `gen_keypair()` is thread-safe provided
+/// [`sodiumoxide::init()`](../../../fn.init.html) has been called and has returned
+/// `true` before using any other function from sodiumoxide.
 pub fn gen_keypair() -> (PublicKey, SecretKey) {
     unsafe {
         let mut pk = [0u8; PUBLICKEYBYTES];
@@ -60,9 +60,9 @@ pub fn gen_keypair() -> (PublicKey, SecretKey) {
 
 /// `gen_nonce()` randomly generates a nonce
 ///
-/// THREAD SAFETY: `gen_nonce()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
+/// THREAD SAFETY: `gen_nonce()` is thread-safe provided
+/// [`sodiumoxide::init()`](../../../fn.init.html) has been called and has returned
+/// `true` before using any other function from sodiumoxide.
 pub fn gen_nonce() -> Nonce {
     let mut n = [0; NONCEBYTES];
     randombytes_into(&mut n);

--- a/src/crypto/pwhash/scryptsalsa208sha256.rs
+++ b/src/crypto/pwhash/scryptsalsa208sha256.rs
@@ -62,8 +62,9 @@ new_type! {
 
 /// `gen_salt()` randombly generates a new `Salt` for key derivation
 ///
-/// THREAD SAFETY: `gen_salt()` is thread-safe provided that you have called
-/// `sodiumoxide::init()` once before using any other function from sodiumoxide.
+/// THREAD SAFETY: `gen_salt()` is thread-safe provided
+/// [`sodiumoxide::init()`](../../../fn.init.html) has been called and has returned
+/// `true` before using any other function from sodiumoxide.
 pub fn gen_salt() -> Salt {
     let mut salt = Salt([0; SALTBYTES]);
     {

--- a/src/crypto/secretbox/xsalsa20poly1305.rs
+++ b/src/crypto/secretbox/xsalsa20poly1305.rs
@@ -33,9 +33,9 @@ const BOXZEROBYTES: usize = 16;
 
 /// `gen_key()` randomly generates a secret key
 ///
-/// THREAD SAFETY: `gen_key()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
+/// THREAD SAFETY: `gen_key()` is thread-safe provided
+/// [`sodiumoxide::init()`](../../../fn.init.html) has been called and has returned
+/// `true` before using any other function from sodiumoxide.
 pub fn gen_key() -> Key {
     let mut key = [0; KEYBYTES];
     randombytes_into(&mut key);
@@ -44,9 +44,9 @@ pub fn gen_key() -> Key {
 
 /// `gen_nonce()` randomly generates a nonce
 ///
-/// THREAD SAFETY: `gen_key()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
+/// THREAD SAFETY: `gen_nonce()` is thread-safe provided
+/// [`sodiumoxide::init()`](../../../fn.init.html) has been called and has returned
+/// `true` before using any other function from sodiumoxide.
 pub fn gen_nonce() -> Nonce {
     let mut nonce = [0; NONCEBYTES];
     randombytes_into(&mut nonce);

--- a/src/crypto/shorthash/siphash24.rs
+++ b/src/crypto/shorthash/siphash24.rs
@@ -24,9 +24,9 @@ new_type! {
 
 /// `gen_key()` randomly generates a key for shorthash
 ///
-/// THREAD SAFETY: `gen_key()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
+/// THREAD SAFETY: `gen_key()` is thread-safe provided
+/// [`sodiumoxide::init()`](../../../fn.init.html) has been called and has returned
+/// `true` before using any other function from sodiumoxide.
 pub fn gen_key() -> Key {
     let mut k = [0; KEYBYTES];
     randombytes_into(&mut k);

--- a/src/crypto/sign/ed25519.rs
+++ b/src/crypto/sign/ed25519.rs
@@ -51,9 +51,9 @@ new_type! {
 /// `gen_keypair()` randomly generates a secret key and a corresponding public
 /// key.
 ///
-/// THREAD SAFETY: `gen_keypair()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
+/// THREAD SAFETY: `gen_keypair()` is thread-safe provided
+/// [`sodiumoxide::init()`](../../../fn.init.html) has been called and has returned
+/// `true` before using any other function from sodiumoxide.
 pub fn gen_keypair() -> (PublicKey, SecretKey) {
     unsafe {
         let mut pk = [0u8; PUBLICKEYBYTES];

--- a/src/crypto/sign/edwards25519sha512batch.rs
+++ b/src/crypto/sign/edwards25519sha512batch.rs
@@ -30,9 +30,9 @@ new_type! {
 /// `gen_keypair()` randomly generates a secret key and a corresponding public
 /// key.
 ///
-/// THREAD SAFETY: `gen_keypair()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
+/// THREAD SAFETY: `gen_keypair()` is thread-safe provided
+/// [`sodiumoxide::init()`](../../../fn.init.html) has been called and has returned
+/// `true` before using any other function from sodiumoxide.
 pub fn gen_keypair() -> (PublicKey, SecretKey) {
     unsafe {
         let mut pk = [0u8; PUBLICKEYBYTES];

--- a/src/crypto/stream/stream_macros.rs
+++ b/src/crypto/stream/stream_macros.rs
@@ -29,9 +29,9 @@ new_type! {
 
 /// `gen_key()` randomly generates a key for symmetric encryption
 ///
-/// THREAD SAFETY: `gen_key()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
+/// THREAD SAFETY: `gen_key()` is thread-safe provided
+/// [`sodiumoxide::init()`](../../../fn.init.html) has been called and has returned
+/// `true` before using any other function from sodiumoxide.
 pub fn gen_key() -> Key {
     let mut key = [0; KEYBYTES];
     randombytes_into(&mut key);
@@ -40,9 +40,9 @@ pub fn gen_key() -> Key {
 
 /// `gen_nonce()` randomly generates a nonce for symmetric encryption
 ///
-/// THREAD SAFETY: `gen_nonce()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
+/// THREAD SAFETY: `gen_nonce()` is thread-safe provided
+/// [`sodiumoxide::init()`](../../../fn.init.html) has been called and has returned
+/// `true` before using any other function from sodiumoxide.
 ///
 /// NOTE: When using primitives with short nonces (e.g. salsa20, salsa208, salsa2012)
 /// do not use random nonces since the probability of nonce-collision is not negligible

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,11 @@
 //! functions in `crypto::scalarmult`, `crypto::stream`, `crypto::auth` and
 //! `crypto::onetimeauth`.
 //!
-//! ## Thread Safety
-//! All functions in this library are thread-safe provided that the `init()`
-//! function has been called during program execution.
+//! # Thread Safety
+//! All functions in this library are thread-safe provided that the
+//! [`init()`](fn.init.html) function has been called during program execution.
+//! `init()` itself is thread-safe, although it will only report success a
+//! maximum of once.
 //!
 //! If `init()` hasn't been called then all functions except the random-number
 //! generation functions and the key-generation functions are thread-safe.
@@ -56,12 +58,25 @@ extern crate rustc_serialize;
 
 /// `init()` initializes the sodium library and chooses faster versions of
 /// the primitives if possible. `init()` also makes the random number generation
-/// functions (`gen_key`, `gen_keypair`, `gen_nonce`, `randombytes`, `randombytes_into`)
-/// thread-safe
+/// functions (`gen_key`, `gen_keypair`, `gen_nonce`, `gen_salt`, `randombytes`,
+/// `randombytes_into`) thread-safe.
+///
+/// It is safe to call this function multiple times even concurrently from
+/// different threads. It will return `true` the first time the initialization
+/// succeeds, otherwise it will return `false`.
 pub fn init() -> bool {
-    unsafe {
-        ffi::sodium_init() != -1
-    }
+    use std::sync::{Once, ONCE_INIT};
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let ran_init = AtomicBool::new(false);
+    static INIT: Once = ONCE_INIT;
+    INIT.call_once(|| {
+        let init_result = unsafe {
+            ffi::sodium_init() == 0
+        };
+        ran_init.store(init_result, Ordering::Relaxed);
+    });
+    ran_init.load(Ordering::Relaxed)
 }
 
 mod marshal;
@@ -86,4 +101,33 @@ pub mod crypto {
     pub mod stream;
     pub mod shorthash;
     pub mod verify;
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_init() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::thread;
+
+        let thread_count = 16;
+        let init_success_count = Arc::new(AtomicUsize::new(0));
+        let mut threads = vec![];
+
+        for _ in 0..thread_count {
+            let local_count = init_success_count.clone();
+            threads.push(thread::spawn(move || {
+                if super::init() {
+                    let _ = local_count.fetch_add(1, Ordering::SeqCst);
+                }
+            }));
+        }
+
+        for thread_handle in threads {
+            let _ = thread_handle.join();
+        }
+
+        assert!(init_success_count.load(Ordering::SeqCst) <= 1);
+    }
 }

--- a/src/randombytes.rs
+++ b/src/randombytes.rs
@@ -4,9 +4,9 @@ use std::iter::repeat;
 
 /// `randombytes()` randomly generates size bytes of data.
 ///
-/// THREAD SAFETY: `randombytes()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
+/// THREAD SAFETY: `randombytes()` is thread-safe provided
+/// [`sodiumoxide::init()`](../fn.init.html) has been called and has returned
+/// `true` before using any other function from sodiumoxide.
 pub fn randombytes(size: usize) -> Vec<u8> {
     unsafe {
         let mut buf: Vec<u8> = repeat(0u8).take(size).collect();
@@ -18,9 +18,9 @@ pub fn randombytes(size: usize) -> Vec<u8> {
 
 /// `randombytes_into()` fills a buffer `buf` with random data.
 ///
-/// THREAD SAFETY: `randombytes_into()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
+/// THREAD SAFETY: `randombytes_into()` is thread-safe provided
+/// [`sodiumoxide::init()`](../fn.init.html) has been called and has returned
+/// `true` before using any other function from sodiumoxide.
 pub fn randombytes_into(buf: &mut [u8]) {
     unsafe {
         ffi::randombytes_buf(buf.as_mut_ptr(), buf.len());


### PR DESCRIPTION
I believe this makes it safe for users to call `init()` concurrently.

The test doesn't check that any `init()` call actually succeeded, only that it didn't execute the call more than once.  Ideally I'd like to have checked that it returned success exactly once, but I don't know if that's reasonable - i.e. if there are environments where the library can still be used safely despite `init()` returning `false`.

Also, since the tests run in parallel by default, I think we should be calling `init()` at the start of every test.  This PR makes it safe to do that now, although I plan to make that change in a separate PR if you agree and are OK with this one.