### PR TITLE
Removed sudo usage from Travis script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: rust
+sudo: false
 install:
 - wget https://github.com/jedisct1/libsodium/releases/download/1.0.6/libsodium-1.0.6.tar.gz
 - tar xvfz libsodium-1.0.6.tar.gz
-- cd libsodium-1.0.6 && ./configure --prefix=/usr && make && sudo make install &&
+- cd libsodium-1.0.6 && ./configure --prefix=$HOME/installed_libsodium && make && make install &&
   cd ..
+- export PKG_CONFIG_PATH=$HOME/installed_libsodium/lib/pkgconfig:$PKG_CONFIG_PATH
+- export LD_LIBRARY_PATH=$HOME/installed_libsodium/lib:$LD_LIBRARY_PATH
 script:
 - cargo build --verbose
 - cargo test --verbose


### PR DESCRIPTION
This allows us to use Travis' preferred container-based infrastructure as per [the Travis docs](https://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade).