### PR TITLE
libsodium-sys: Improve generichash bindings

### DIFF
--- a/libsodium-sys/src/crypto_generichash.rs
+++ b/libsodium-sys/src/crypto_generichash.rs
@@ -94,3 +94,55 @@ fn test_crypto_generichash_primitive() {
         assert_eq!(s, crypto_generichash_PRIMITIVE.as_bytes());
     }
 }
+
+#[test]
+fn test_crypto_generichash_statebytes() {
+    assert!(unsafe { crypto_generichash_statebytes() } > 0);
+}
+
+#[test]
+fn test_crypto_generichash() {
+    let mut out = [0u8; crypto_generichash_BYTES];
+    let m = [0u8; 64];
+    let key = [0u8; crypto_generichash_KEYBYTES];
+
+    assert_eq!(unsafe {
+        crypto_generichash(out.as_mut_ptr(), out.len(),
+                           m.as_ptr(), m.len() as u64,
+                           key.as_ptr(), key.len())
+    }, 0);
+}
+
+#[cfg(test)]
+use std::mem;
+
+#[test]
+fn test_crypto_generichash_multipart() {
+    let mut out = [0u8; crypto_generichash_BYTES];
+    let m = [0u8; 64];
+    let key = [0u8; crypto_generichash_KEYBYTES];
+
+    let mut st = vec![0u8; (unsafe { crypto_generichash_statebytes() })];
+    let pst = unsafe { mem::transmute::<*mut u8, *mut crypto_generichash_state>(st.as_mut_ptr()) };
+
+    assert_eq!(unsafe {
+        crypto_generichash_init(pst,
+                                key.as_ptr(), key.len(),
+                                out.len())
+    }, 0);
+
+    assert_eq!(unsafe {
+        crypto_generichash_update(pst,
+                                m.as_ptr(), m.len() as u64)
+    }, 0);
+
+    assert_eq!(unsafe {
+        crypto_generichash_update(pst,
+                                m.as_ptr(), m.len() as u64)
+    }, 0);
+
+    assert_eq!(unsafe {
+        crypto_generichash_final(pst,
+                                out.as_mut_ptr(), out.len())
+    }, 0);
+}

--- a/libsodium-sys/src/crypto_generichash.rs
+++ b/libsodium-sys/src/crypto_generichash.rs
@@ -8,6 +8,9 @@ pub const crypto_generichash_KEYBYTES_MAX: usize = crypto_generichash_blake2b_KE
 pub const crypto_generichash_KEYBYTES: usize = crypto_generichash_blake2b_KEYBYTES;
 pub const crypto_generichash_PRIMITIVE: &'static str = "blake2b";
 
+#[allow(non_camel_case_types)]
+pub enum crypto_generichash_state { }
+
 extern {
     pub fn crypto_generichash_bytes_min() -> size_t;
     pub fn crypto_generichash_bytes_max() -> size_t;
@@ -25,6 +28,27 @@ extern {
         key: *const u8,
         keylen: size_t)
         -> c_int;
+
+    pub fn crypto_generichash_init(
+        state: *mut crypto_generichash_state,
+        key: *const u8,
+        keylen: size_t,
+        outlen: size_t)
+        -> c_int;
+
+    pub fn crypto_generichash_update(
+        state: *mut crypto_generichash_state,
+        in_: *const u8,
+        inlen: c_ulonglong)
+        -> c_int;
+
+    pub fn crypto_generichash_final(
+        state: *mut crypto_generichash_state,
+        out: *mut u8,
+        outlen: size_t)
+        -> c_int;
+
+    pub fn crypto_generichash_statebytes() -> size_t;
 }
 
 #[test]

--- a/libsodium-sys/src/crypto_generichash_blake2b.rs
+++ b/libsodium-sys/src/crypto_generichash_blake2b.rs
@@ -118,3 +118,32 @@ fn test_crypto_generichash_blake2b_personalbytes() {
     assert_eq!(unsafe { crypto_generichash_blake2b_personalbytes() as usize },
                         crypto_generichash_blake2b_PERSONALBYTES)
 }
+
+#[test]
+fn test_crypto_generichash_blake2b() {
+    let mut out = [0u8; crypto_generichash_blake2b_BYTES];
+    let m = [0u8; 64];
+    let key = [0u8; crypto_generichash_blake2b_KEYBYTES];
+
+    assert_eq!(unsafe {
+        crypto_generichash_blake2b(out.as_mut_ptr(), out.len(),
+                           m.as_ptr(), m.len() as u64,
+                           key.as_ptr(), key.len())
+    }, 0);
+}
+
+#[test]
+fn test_crypto_generichash_blake2b_salt_personal() {
+    let mut out = [0u8; crypto_generichash_blake2b_BYTES];
+    let m = [0u8; 64];
+    let key = [0u8; crypto_generichash_blake2b_KEYBYTES];
+    let salt = [0u8; crypto_generichash_blake2b_SALTBYTES];
+    let personal = [0u8; crypto_generichash_blake2b_PERSONALBYTES];
+
+    assert_eq!(unsafe {
+        crypto_generichash_blake2b_salt_personal(out.as_mut_ptr(), out.len(),
+                           m.as_ptr(), m.len() as u64,
+                           key.as_ptr(), key.len(),
+                           &salt, &personal)
+    }, 0);
+}

--- a/libsodium-sys/src/crypto_generichash_blake2b.rs
+++ b/libsodium-sys/src/crypto_generichash_blake2b.rs
@@ -9,6 +9,8 @@ pub const crypto_generichash_blake2b_KEYBYTES: usize = 32;
 pub const crypto_generichash_blake2b_SALTBYTES: usize = 16;
 pub const crypto_generichash_blake2b_PERSONALBYTES: usize = 16;
 
+#[allow(non_camel_case_types)]
+pub enum crypto_generichash_blake2b_state { }
 
 extern {
     pub fn crypto_generichash_blake2b_bytes_min() -> size_t;
@@ -38,6 +40,34 @@ extern {
         keylen: size_t,
         salt: *const [u8; crypto_generichash_blake2b_SALTBYTES],
         personal: *const [u8; crypto_generichash_blake2b_PERSONALBYTES])
+        -> c_int;
+
+    pub fn crypto_generichash_blake2b_init(
+        state: *mut crypto_generichash_blake2b_state,
+        key: *const u8,
+        keylen: size_t,
+        outlen: size_t)
+        -> c_int;
+
+    pub fn crypto_generichash_blake2b_init_salt_personal(
+        state: *mut crypto_generichash_blake2b_state,
+        key: *const u8,
+        keylen: size_t,
+        outlen: size_t,
+        salt: *const [u8; crypto_generichash_blake2b_SALTBYTES],
+        personal: *const [u8; crypto_generichash_blake2b_PERSONALBYTES])
+        -> c_int;
+
+    pub fn crypto_generichash_blake2b_update(
+        state: *mut crypto_generichash_blake2b_state,
+        in_: *const u8,
+        inlen: c_ulonglong)
+        -> c_int;
+
+    pub fn crypto_generichash_blake2b_final(
+        state: *mut crypto_generichash_blake2b_state,
+        out: *mut u8,
+        outlen: size_t)
         -> c_int;
 }
 


### PR DESCRIPTION
These commits add additional bindings and test cases for generichash functions.