### PR TITLE
Add sodium_(malloc|free|mprotect_*)

### DIFF
--- a/libsodium-sys/lib.rs
+++ b/libsodium-sys/lib.rs
@@ -1,7 +1,7 @@
 #![allow(non_upper_case_globals)]
 
 extern crate libc;
-use libc::{c_int, c_ulonglong, c_char, size_t};
+use libc::{c_void, c_int, c_ulonglong, c_char, size_t};
 
 include!("src/core.rs");
 

--- a/libsodium-sys/src/utils.rs
+++ b/libsodium-sys/src/utils.rs
@@ -4,4 +4,12 @@ extern {
     pub fn sodium_memzero(pnt: *mut u8, len: size_t);
     pub fn sodium_memcmp(b1_: *const u8, b2_: *const u8, len: size_t) -> c_int;
     pub fn sodium_increment(n: *mut u8, len: size_t);
+
+    pub fn sodium_malloc(len: size_t) -> *mut c_void;
+    pub fn sodium_allocarray(count: size_t, size: size_t) -> *mut c_void;
+    pub fn sodium_free(ptr: *mut c_void);
+
+    pub fn sodium_mprotect_noaccess(ptr: *const c_void) -> c_int;
+    pub fn sodium_mprotect_readonly(ptr: *const c_void) -> c_int;
+    pub fn sodium_mprotect_readwrite(ptr: *const c_void) -> c_int;
 }


### PR DESCRIPTION
Add FFI bindings to more `sodium/utils.c` functions.