### PR TITLE
Wrap sodium allocators

### DIFF
--- a/libsodium-sys/lib.rs
+++ b/libsodium-sys/lib.rs
@@ -1,7 +1,7 @@
 #![allow(non_upper_case_globals)]
 
 extern crate libc;
-use libc::{c_int, c_ulonglong, c_char, size_t};
+use libc::{c_void, c_int, c_ulonglong, c_char, size_t};
 
 include!("src/core.rs");
 

--- a/libsodium-sys/src/utils.rs
+++ b/libsodium-sys/src/utils.rs
@@ -4,4 +4,12 @@ extern {
     pub fn sodium_memzero(pnt: *mut u8, len: size_t);
     pub fn sodium_memcmp(b1_: *const u8, b2_: *const u8, len: size_t) -> c_int;
     pub fn sodium_increment(n: *mut u8, len: size_t);
+
+    pub fn sodium_malloc(len: size_t) -> *mut c_void;
+    pub fn sodium_allocarray(count: size_t, size: size_t) -> *mut c_void;
+    pub fn sodium_free(ptr: *mut c_void);
+
+    pub fn sodium_mprotect_noaccess(ptr: *const c_void) -> c_int;
+    pub fn sodium_mprotect_readonly(ptr: *const c_void) -> c_int;
+    pub fn sodium_mprotect_readwrite(ptr: *const c_void) -> c_int;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,36 @@
 //! Libsodium utility functions
 use ffi;
 
+use std::mem;
+
+/// `malloc()` tries to securely allocate enough memory on the heap to
+/// store `len` bytes. The memory region is bounded on both sides by
+/// guard pages, and, when possible, prevented from being paged out to
+/// swap. It is not guaranteed to be aligned. Memory allocated this
+/// way must have `free()` called when it is no longer in use. Callers
+/// must ensure that a null pointer was not returned before using the
+/// result.
+pub unsafe fn malloc(len: usize) -> *mut u8 {
+    ffi::sodium_malloc(len) as *mut u8
+}
+
+/// `allocarray()` tries to securely allocate enough memory on the
+/// heap to store `count` objects of type `T`. It provides the same
+/// security guarantees as `malloc()`, and must also have `free()`
+/// called on its result when no longer used. Callers must ensure that
+/// a null pointer was not returned before using the result.
+pub unsafe fn allocarray<T>(count: usize) -> *mut T {
+    ffi::sodium_allocarray(count, mem::size_of::<T>()) as *mut T
+}
+
+/// `free()` frees memory allocated by this library's `malloc()` and
+/// `allocarray()` functions, zeroing out memory used in the
+/// process. In the event that an overflow or underflow write was
+/// detected, it will panic.
+pub unsafe fn free(ptr: *mut u8) {
+    ffi::sodium_free(ptr as *mut _);
+}
+
 /// `memzero()` tries to effectively zero out the data in `x` even if
 /// optimizations are being applied to the code.
 pub fn memzero(x: &mut [u8]) {


### PR DESCRIPTION
Implements basic wrappers on `sodium_malloc`, `sodium_allocarray`, and `sodium_free`. This is based on my previous PR, so we can merge that one independently and discuss the merits of whether or not to include these wrappers in sodiumoxide directly.