### PR TITLE
libsodium-sys: Remove bindings & tests for functions that no longer exist in libsodium

### DIFF
--- a/libsodium-sys/src/crypto_sign_edwards25519sha512batch.rs
+++ b/libsodium-sys/src/crypto_sign_edwards25519sha512batch.rs
@@ -24,27 +24,4 @@ extern {
         smlen: c_ulonglong,
         pk: *const [u8; crypto_sign_edwards25519sha512batch_PUBLICKEYBYTES]) ->
         c_int;
-    pub fn crypto_sign_edwards25519sha512batch_bytes() -> size_t;
-    pub fn crypto_sign_edwards25519sha512batch_publickeybytes() -> size_t;
-    pub fn crypto_sign_edwards25519sha512batch_secretkeybytes() -> size_t;
-}
-
-
-#[test]
-fn test_crypto_sign_edwards25519sha512batch_bytes() {
-    assert!(unsafe {
-        crypto_sign_edwards25519sha512batch_bytes() as usize
-    } == crypto_sign_edwards25519sha512batch_BYTES)
-}
-#[test]
-fn test_crypto_sign_edwards25519sha512batch_publickeybytes() {
-    assert!(unsafe {
-        crypto_sign_edwards25519sha512batch_publickeybytes() as usize
-    } == crypto_sign_edwards25519sha512batch_PUBLICKEYBYTES)
-}
-#[test]
-fn test_crypto_sign_edwards25519sha512batch_secretkeybytes() {
-    assert!(unsafe {
-        crypto_sign_edwards25519sha512batch_secretkeybytes() as usize
-    } == crypto_sign_edwards25519sha512batch_SECRETKEYBYTES)
 }


### PR DESCRIPTION
The symbols disappeared in commit jedisct1/libsodium@2ff0ec3aa1a5d0b6dc3a8d723f8f38fcf7fea82e and the prototypes were removed in jedisct1/libsodium@e153debd0ddb40eb308e629dc6d3b22b83f86289.

Without this change, the libsodium-sys tests won't build with libsodium version 1.0.7 or 1.0.8.