### PR TITLE
Loosen version constraints on dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ repository = "https://github.com/dnaq/sodiumoxide"
 version = "0.0.9"
 
 [dependencies]
-libc = "0.2.1"
+libc = "0.2"
 libsodium-sys = "0.0.9"
-rustc-serialize = { version = "0.3.16", optional = true }
+rustc-serialize = { version = "0.3", optional = true }
 
 [dev-dependencies]
-rustc-serialize = "0.3.16"
+rustc-serialize = "0.3"
 
 [features]
 benchmarks = []

--- a/libsodium-sys/Cargo.toml
+++ b/libsodium-sys/Cargo.toml
@@ -11,10 +11,10 @@ repository = "https://github.com/dnaq/sodiumoxide.git"
 version = "0.0.9"
 
 [build-dependencies]
-pkg-config = "0.3.6"
+pkg-config = "0.3"
 
 [dependencies]
-libc = "0.2.1"
+libc = "0.2"
 
 [lib]
 name = "libsodium_sys"


### PR DESCRIPTION


pkg-config 0.3.7 is out. Since openssl-sys depends on `pkg-config =
"0.3"`, Cargo selects 0.3.7. However, since libsodium-sys depends on the
exact PATCH version, we get a version conflict.

We drop the PATCH segment from our version requirements, allowing Cargo
to choose any version 0.3.y for any value of y.