### PR TITLE
libsodium version function

### DIFF
--- a/libsodium-sys/lib.rs
+++ b/libsodium-sys/lib.rs
@@ -53,3 +53,4 @@ include!("src/crypto_verify_64.rs");
 
 include!("src/randombytes.rs");
 include!("src/utils.rs");
+include!("src/version.rs");

--- a/libsodium-sys/src/version.rs
+++ b/libsodium-sys/src/version.rs
@@ -2,4 +2,6 @@
 
 extern {
     pub fn sodium_version_string() -> *const c_char;
+    pub fn sodium_library_version_major() -> c_int;
+    pub fn sodium_library_version_minor() -> c_int;
 }

--- a/libsodium-sys/src/version.rs
+++ b/libsodium-sys/src/version.rs
@@ -1,0 +1,5 @@
+// version.h
+
+extern {
+    pub fn sodium_version_string() -> *const c_char;
+}

--- a/libsodium-sys/src/version.rs
+++ b/libsodium-sys/src/version.rs
@@ -5,3 +5,13 @@ extern {
     pub fn sodium_library_version_major() -> c_int;
     pub fn sodium_library_version_minor() -> c_int;
 }
+
+#[test]
+fn test_sodium_library_version_major() {
+    assert!(unsafe { sodium_library_version_major() } > 0)
+}
+
+#[test]
+fn test_sodium_library_version_minor() {
+    assert!(unsafe { sodium_library_version_minor() } >= 0)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ mod marshal;
 mod newtype_macros;
 pub mod randombytes;
 pub mod utils;
+pub mod version;
 
 #[cfg(test)]
 mod test_utils;

--- a/src/version.rs
+++ b/src/version.rs
@@ -10,6 +10,20 @@ pub fn version_string() -> &'static str {
     version.to_str().unwrap()
 }
 
+/// `version_major()` returns the major version from libsodium.
+pub fn version_major() -> i32 {
+    unsafe {
+        ffi::sodium_library_version_major()
+    }
+}
+
+/// `version_minor()` returns the minor version from libsodium.
+pub fn version_minor() -> i32 {
+    unsafe {
+        ffi::sodium_library_version_minor()
+    }
+}
+
 #[cfg(test)]
 mod test {
     #[test]

--- a/src/version.rs
+++ b/src/version.rs
@@ -11,16 +11,16 @@ pub fn version_string() -> &'static str {
 }
 
 /// `version_major()` returns the major version from libsodium.
-pub fn version_major() -> i32 {
+pub fn version_major() -> usize {
     unsafe {
-        ffi::sodium_library_version_major()
+        ffi::sodium_library_version_major() as usize
     }
 }
 
 /// `version_minor()` returns the minor version from libsodium.
-pub fn version_minor() -> i32 {
+pub fn version_minor() -> usize {
     unsafe {
-        ffi::sodium_library_version_minor()
+        ffi::sodium_library_version_minor() as usize
     }
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -3,11 +3,11 @@ use ffi;
 use std::ffi::CStr;
 
 /// `version_string()` returns the version string from libsodium.
-pub fn version_string() -> String {
+pub fn version_string() -> &'static str {
     let version = unsafe {
         CStr::from_ptr(ffi::sodium_version_string())
     };
-    version.to_str().unwrap().to_string()
+    version.to_str().unwrap()
 }
 
 #[cfg(test)]

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,20 @@
+//! Libsodium version functions
+use ffi;
+use std::ffi::CStr;
+
+/// `version_string()` returns the version string from libsodium.
+pub fn version_string() -> String {
+    let version = unsafe {
+        CStr::from_ptr(ffi::sodium_version_string())
+    };
+    version.to_str().unwrap().to_string()
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_version_string() {
+        use version::version_string;
+        assert!(!version_string().is_empty());
+    }
+}


### PR DESCRIPTION
This PR adds a new function, `version::version_string` - it just calls through to libsodium's `sodium_version_string()` \[1\].

This PR suits my needs, but I'm not sure it's complete:
1) Is there enough documentation?
2) Is there enough testing? I'm not sure how to do any better, but it does feel light.
3) Should I expose `sodium_library_version_major()` and `sodium_library_version_minor()`?

Thanks for your time and consideration.

\[1\]: https://github.com/jedisct1/libsodium/blob/master/src/libsodium/sodium/version.c