### PR TITLE
Make vector manipulation more efficient.

### DIFF
--- a/src/marshal.rs
+++ b/src/marshal.rs
@@ -8,12 +8,11 @@ pub fn marshal<T, F>(buf: &[u8],
                      ) -> (Vec<u8>, T)
     where F: Fn(*mut u8, *const u8, c_ulonglong) -> T {
     let mut dst = Vec::with_capacity(buf.len() + padbefore);
-    for _ in 0..padbefore {
-        dst.push(0);
-    }
-    dst.extend(buf.into_iter());
+    dst.resize(padbefore, 0u8);
+    dst.extend_from_slice(&buf[..]);
     let pdst = dst.as_mut_ptr();
     let psrc = dst.as_ptr();
     let res = f(pdst, psrc, dst.len() as c_ulonglong);
-    (dst.into_iter().skip(bytestodrop).collect(), res)
+    dst.drain(..bytestodrop);
+    (dst, res)
 }


### PR DESCRIPTION
This should not change the functionality of this function. It just modifies it to use constructs that are easier for the current Rust compiler to optimize (before specialization lands; not sure how much that will help).

I ran the benchmarks twice on my old and slow laptop to see if there were any consistent improvement. The small diffs seem to be part of the variation, but there does seem to be a significant gain for at least the xsalsa20poly1305 routine. Feel free to give it shot as well :-)

https://gist.github.com/brinchj/19b24ccdf34f07b7aaca22edf5e8dbfd

Note that drain() just does a memmove, so the removal of prefix-bytes is now inplace.