### PR TITLE
Use better build script keys

### DIFF
--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -5,13 +5,13 @@ fn main() {
 
     if let Ok(lib_dir) = env::var("SODIUM_LIB_DIR") {
 
-    	println!("cargo:rustc-flags=-L native={}", lib_dir);
+    	println!("cargo:rustc-link-search=native={}", lib_dir);
 
         let mode = match env::var_os("SODIUM_STATIC") {
             Some(_) => "static",
             None => "dylib"
         };
-        println!("cargo:rustc-flags=-l {0}=sodium", mode);
+        println!("cargo:rustc-link-lib={0}=sodium", mode);
 
     } else {
 


### PR DESCRIPTION
`rustc-flags` is so old it isn't even documented on crates.io anymore and is effectively deprecated.