### PR TITLE
Add randombytes_uniform function

### DIFF
--- a/libsodium-sys/src/randombytes.rs
+++ b/libsodium-sys/src/randombytes.rs
@@ -3,4 +3,5 @@
 extern {
     pub fn randombytes_buf(buf: *mut u8,
                            size: size_t);
+    pub fn randombytes_uniform(upper_bound: u32) -> u32;
 }

--- a/src/randombytes.rs
+++ b/src/randombytes.rs
@@ -26,3 +26,38 @@ pub fn randombytes_into(buf: &mut [u8]) {
         ffi::randombytes_buf(buf.as_mut_ptr(), buf.len());
     }
 }
+
+/// `randombytes_uniform()` returns an unpredictable value between 0 and
+/// `upper_bound` (excluded). It does its best to guarantee a uniform
+/// distribution of the possible output values.
+///
+/// THREAD SAFETY: `randombytes_uniform()` is thread-safe provided that you
+/// have called `sodiumoxide::init()` once before using any other function
+/// from sodiumoxide.
+pub fn randombytes_uniform(upper_bound: u32) -> u32 {
+    unsafe {
+        ffi::randombytes_uniform(upper_bound)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_randombytes_uniform_lt1000() {
+        for _ in 0..100 {
+            let random = randombytes_uniform(1000);
+            assert!(random < 1000);
+        }
+    }
+
+    #[test]
+    fn test_randombytes_uniform_lt3() {
+        for _ in 0..100 {
+            let random = randombytes_uniform(3);
+            assert!(random < 3);
+        }
+    }
+
+}

--- a/src/randombytes.rs
+++ b/src/randombytes.rs
@@ -53,6 +53,14 @@ mod test {
     }
 
     #[test]
+    /// Make sure that not all random numbers are the same.
+    fn test_randombytes_uniform_not_stuck() {
+        let random_numbers = (2..100).map(|_| randombytes_uniform(100)).collect::<Vec<u32>>();
+        let first = random_numbers[0];
+        assert!(!random_numbers.iter().all(|n| *n == first));
+    }
+
+    #[test]
     fn test_randombytes_uniform_edge_cases() {
         assert_eq!(randombytes_uniform(0), 0);
         assert_eq!(randombytes_uniform(1), 0);

--- a/src/randombytes.rs
+++ b/src/randombytes.rs
@@ -45,19 +45,17 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_randombytes_uniform_lt1000() {
-        for _ in 0..100 {
-            let random = randombytes_uniform(1000);
-            assert!(random < 1000);
+    fn test_randombytes_uniform() {
+        for i in 2..300 {
+            let random = randombytes_uniform(i);
+            assert!(random < i);
         }
     }
 
     #[test]
-    fn test_randombytes_uniform_lt3() {
-        for _ in 0..100 {
-            let random = randombytes_uniform(3);
-            assert!(random < 3);
-        }
+    fn test_randombytes_uniform_edge_cases() {
+        assert_eq!(randombytes_uniform(0), 0);
+        assert_eq!(randombytes_uniform(1), 0);
     }
 
 }


### PR DESCRIPTION
I added access to the [randombytes_uniform](https://download.libsodium.org/libsodium/content/generating_random_data/#usage) function.

Please make sure that everything is correct, this is my first FFI related Rust code :)

I'm not sure if there's a way to test the randomness of the data. Even asserting that the number is not the same as the previous 2 numbers could fail [in rare but valid cases](http://dilbert.com/strip/2001-10-25). Right now I just test 100 times that the number is smaller than the upper bound.

What we could maybe do is do it 1000 times and get the average. It should probably lie somewhere around `upper_bound / 2`.