### PR TITLE
implement seal_detached_inplace and open_detached_inplace

### DIFF
--- a/libsodium-sys/src/crypto_box.rs
+++ b/libsodium-sys/src/crypto_box.rs
@@ -102,6 +102,22 @@ extern {
         pk: *const [u8; crypto_box_PUBLICKEYBYTES],
         sk: *const [u8; crypto_box_SECRETKEYBYTES])
         -> c_int;
+    pub fn crypto_box_detached_afternm(
+        c: *mut u8,
+        mac: *mut [u8; crypto_box_MACBYTES],
+        m: *const u8,
+        mlen: c_ulonglong,
+        n: *const [u8; crypto_box_NONCEBYTES],
+        k: *const [u8; crypto_box_BEFORENMBYTES])
+        -> c_int;
+    pub fn crypto_box_open_detached_afternm(
+        m: *mut u8,
+        c: *const u8,
+        mac: *const [u8; crypto_box_MACBYTES],
+        clen: c_ulonglong,
+        n: *const [u8; crypto_box_NONCEBYTES],
+        k: *const [u8; crypto_box_BEFORENMBYTES])
+        -> c_int;
     pub fn crypto_box_seal(
         c: *mut u8,
         m: *const u8,

--- a/libsodium-sys/src/crypto_secretbox.rs
+++ b/libsodium-sys/src/crypto_secretbox.rs
@@ -17,6 +17,20 @@ extern {
         clen: c_ulonglong,
         n: *const [u8; crypto_secretbox_NONCEBYTES],
         k: *const [u8; crypto_secretbox_KEYBYTES]) -> c_int;
+    pub fn crypto_secretbox_detached(
+        c: *mut u8,
+        mac: *mut [u8; crypto_secretbox_MACBYTES],
+        m: *const u8,
+        mlen: c_ulonglong,
+        n: *const [u8; crypto_secretbox_NONCEBYTES],
+        k: *const [u8; crypto_secretbox_KEYBYTES]) -> c_int;
+    pub fn crypto_secretbox_open_detached(
+        m: *mut u8,
+        c: *const u8,
+        mac: *const [u8; crypto_secretbox_MACBYTES],
+        clen: c_ulonglong,
+        n: *const [u8; crypto_secretbox_NONCEBYTES],
+        k: *const [u8; crypto_secretbox_KEYBYTES]) -> c_int;
     pub fn crypto_secretbox_keybytes() -> size_t;
     pub fn crypto_secretbox_noncebytes() -> size_t;
     pub fn crypto_secretbox_macbytes() -> size_t;

--- a/src/crypto/secretbox/xsalsa20poly1305.rs
+++ b/src/crypto/secretbox/xsalsa20poly1305.rs
@@ -22,6 +22,13 @@ new_type! {
 }
 
 new_type! {
+    /// Authentication `Tag` for the detached encryption mode
+    ///
+    /// In the combined mode, the tag occupies the first MACBYTES bytes of the ciphertext.
+    public Tag(MACBYTES);
+}
+
+new_type! {
     /// `Nonce` for symmetric authenticated encryption
     nonce Nonce(NONCEBYTES);
 }
@@ -71,6 +78,26 @@ pub fn seal(m: &[u8],
     c
 }
 
+/// `seal_detached()` encrypts and authenticates a message `m` using a secret key `k` and a nonce
+/// `n`.  `m` is encrypted in place, so after this function returns it will contain the ciphertext.
+/// The detached authentication tag is returned by value.
+pub fn seal_detached(m: &mut[u8],
+                     &Nonce(ref n): &Nonce,
+                     &Key(ref k): &Key) -> Tag {
+    let mut tag = [0; MACBYTES];
+    unsafe {
+        ffi::crypto_secretbox_detached(
+            m.as_mut_ptr(),
+            &mut tag,
+            m.as_ptr(),
+            m.len() as u64,
+            n,
+            k,
+        );
+    };
+    Tag(tag)
+}
+
 /// `open()` verifies and decrypts a ciphertext `c` using a secret key `k` and a nonce `n`.
 /// It returns a plaintext `Ok(m)`.
 /// If the ciphertext fails verification, `open()` returns `Err(())`.
@@ -97,6 +124,31 @@ pub fn open(c: &[u8],
     }
 }
 
+/// `open_detached()` verifies and decrypts a ciphertext `c` and and authentication tag `tag`,
+/// using a secret key `k` and a nonce `n`. `c` is decrypted in place, so if this function is
+/// successful it will contain the plaintext. If the ciphertext fails verification,
+/// `open_detached()` returns `Err(())`, and the ciphertext is not modified.
+pub fn open_detached(c: &mut[u8],
+                     tag: &Tag,
+                     &Nonce(ref n): &Nonce,
+                     &Key(ref k): &Key) -> Result<(), ()> {
+    let ret = unsafe {
+        ffi::crypto_secretbox_open_detached(
+            c.as_mut_ptr(),
+            c.as_ptr(),
+            &tag.0,
+            c.len() as u64,
+            n,
+            k,
+        )
+    };
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -110,7 +162,52 @@ mod test {
             let n = gen_nonce();
             let c = seal(&m, &n, &k);
             let opened = open(&c, &n, &k);
-            assert!(Ok(m) == opened);
+            assert_eq!(Ok(m), opened);
+        }
+    }
+
+    #[test]
+    fn test_seal_open_detached() {
+        use randombytes::randombytes;
+        for i in 0..256usize {
+            let k = gen_key();
+            let m = randombytes(i);
+            let n = gen_nonce();
+            let mut buf = m.clone();
+            let tag = seal_detached(&mut buf, &n, &k);
+            open_detached(&mut buf, &tag, &n, &k).unwrap();
+            assert_eq!(m, buf);
+        }
+    }
+
+    #[test]
+    fn test_seal_combined_then_open_detached() {
+        use randombytes::randombytes;
+        for i in 0..256usize {
+            let k = gen_key();
+            let m = randombytes(i);
+            let n = gen_nonce();
+            let mut c = seal(&m, &n, &k);
+            let tag = Tag::from_slice(&c[..MACBYTES]).unwrap();
+            let buf = &mut c[MACBYTES..];
+            open_detached(buf, &tag, &n, &k).unwrap();
+            assert_eq!(buf, &*m);
+        }
+    }
+
+    #[test]
+    fn test_seal_detached_then_open_combined() {
+        use randombytes::randombytes;
+        for i in 0..256usize {
+            let k = gen_key();
+            let m = randombytes(i);
+            let n = gen_nonce();
+            let mut buf = vec![0; MACBYTES];
+            buf.extend_from_slice(&m);
+            let tag = seal_detached(&mut buf[MACBYTES..], &n, &k);
+            buf[..MACBYTES].copy_from_slice(&tag.0[..]);
+            let opened = open(&buf, &n, &k);
+            assert_eq!(Ok(m), opened);
         }
     }
 
@@ -124,10 +221,31 @@ mod test {
             let mut c = seal(&m, &n, &k);
             for i in 0..c.len() {
                 c[i] ^= 0x20;
-                assert!(Err(()) == open(&mut c, &n, &k));
+                // Test the combined mode.
+                assert_eq!(Err(()), open(&mut c, &n, &k));
+                // Test the detached mode.
+                let tag = Tag::from_slice(&c[..MACBYTES]).unwrap();
+                assert_eq!(Err(()), open_detached(&mut c[MACBYTES..], &tag, &n, &k));
                 c[i] ^= 0x20;
             }
         }
+    }
+
+    #[test]
+    fn test_open_inplace_failure_does_not_modify() {
+        let mut buf = b"hello world".to_vec();
+        let k = gen_key();
+        let n = gen_nonce();
+        let tag = seal_detached(&mut buf, &n, &k);
+        // Flip the last bit in the ciphertext, to break authentication.
+        *buf.last_mut().unwrap() ^= 1;
+        // Make a copy that we can compare against after the failure below.
+        let copy = buf.clone();
+        // Now try to open the message. This will fail.
+        let failure = open_detached(&mut buf, &tag, &n, &k);
+        assert!(failure.is_err());
+        // Make sure the input hasn't been touched.
+        assert_eq!(buf, copy, "input should not be modified if authentication fails");
     }
 
     #[test]


### PR DESCRIPTION
https://github.com/dnaq/sodiumoxide/issues/24

This is another take on non-allocating primitives for secretbox. If we
like it, we could do the same thing for box too. There were two
particular design questions in my head for what interface to expose for
this:

1. Combined mode vs detached mode. Detached mode is the lower-level
primitive of the two, and it's easy to implement combined mode as a
wrapper, but not the other way around. This is also how libsodium's
implementation is organized. So I went with detached mode.

2. In-place vs two-buffers. Libsodium supports both, by checking the
pointers to see if they're overlapping. Rust makes it hard to support
both in a single interface, because &mut references can never be
aliased. I think it's easier to wrap an in-place function to become a
two-buffers one than the other way around, so I went with in-place.

Detached-and-in-place has the extra advantage that it can never panic,
because there are no length checks. The length of the tag is statically
known, and any length of the message is valid.