### PR TITLE
Update serde to 0.9.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ version = "0.0.13"
 [dependencies]
 libc = "0.2"
 libsodium-sys = "0.0.13"
-serde = { version="0.8", optional = true }
+serde = { version="0.9", optional = true }
 
 [dev-dependencies]
-serde = "0.8"
-serde_json = "0.8"
+serde = "0.9"
+serde_json = "0.9"
 rustc-serialize = "0.3"
 
 [features]


### PR DESCRIPTION
Updates sodiumoxide to the recently released [serde 0.9](https://github.com/serde-rs/serde/releases/tag/v0.9.0).