### PR TITLE
Remove .cargo/config, specify libsodium-sys path in Cargo.toml

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,1 +1,0 @@
-paths = ["libsodium-sys"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.0.14"
 
 [dependencies]
 libc = "0.2"
-libsodium-sys = "0.0.14"
+libsodium-sys = { version = "0.0.14", path = "libsodium-sys" }
 serde = { version="0.9", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This makes using sodiumoxide from git easier.

Fixes #155.