### PR TITLE
Streaming hashing interface for SHA-2

### DIFF
--- a/src/crypto/hash/hash_macros.rs
+++ b/src/crypto/hash/hash_macros.rs
@@ -1,6 +1,13 @@
-macro_rules! hash_module (($hash_name:ident, $hashbytes:expr, $blockbytes:expr) => (
+macro_rules! hash_module (($hash_name:ident,
+                           $hashbytes:expr,
+                           $blockbytes:expr,
+                           $state_name:ident,
+                           $init_name:ident,
+                           $update_name:ident,
+                           $final_name:ident) => (
 
 use libc::c_ulonglong;
+use std::mem;
 
 /// Number of bytes in a `Digest`.
 pub const DIGESTBYTES: usize = $hashbytes;
@@ -19,6 +26,55 @@ pub fn hash(m: &[u8]) -> Digest {
         let mut h = [0; DIGESTBYTES];
         $hash_name(&mut h, m.as_ptr(), m.len() as c_ulonglong);
         Digest(h)
+    }
+}
+
+// Streaming hashing.
+// Mostly follows the streaming HMAC interface and implementation.
+
+// `Clone` may be used to speed up, e.g., hashing many messages that
+// have a common prefix. It also makes `finalize` moving `State` less
+// inconvenient.
+
+/// State for multi-part (streaming) computation of hash digest.
+#[derive(Clone)]
+pub struct State($state_name);
+
+impl State {
+    /// `init()` initialize a streaming hashing state.
+    pub fn init() -> State {
+        unsafe {
+            let mut s = mem::uninitialized();
+            $init_name(&mut s);
+            State(s)
+        }
+    }
+
+    /// `update()` can be called more than once in order to compute the digest
+    /// from sequential chunks of the message.
+    pub fn update(&mut self, in_: &[u8]) {
+        unsafe {
+            $update_name(&mut self.0, in_.as_ptr(), in_.len() as c_ulonglong);
+        }
+    }
+
+    /// `finalize()` finalizes the hashing computation and returns a `Digest`.
+
+    // Moves self becuase libsodium says the state should not be used
+    // anymore after final().
+    pub fn finalize(mut self) -> Digest {
+        unsafe {
+            let mut digest = [0; $hashbytes as usize];
+            $final_name(&mut self.0, &mut digest);
+            Digest(digest)
+        }
+    }
+}
+
+// Impl Default becuase `State` does have a sensible default: State::init()
+impl Default for State {
+    fn default() -> State {
+        State::init()
     }
 }
 


### PR DESCRIPTION
Fixes #119.

Mostly follows streaming HMAC interface and implementation. Difference from the HMAC part is explained in comments.