### PR TITLE
Add key pair generation from seed also for box

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ rust:
 - nightly
 sudo: false
 install:
-- wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.12.tar.gz
-- tar xvfz libsodium-1.0.12.tar.gz
-- cd libsodium-1.0.12
-- ./configure && make && make install
-- sudo ldconfig /usr/local/lib
+- wget https://github.com/jedisct1/libsodium/releases/download/1.0.8/libsodium-1.0.8.tar.gz
+- tar xvfz libsodium-1.0.8.tar.gz
+- cd libsodium-1.0.8 && ./configure --prefix=$HOME/installed_libsodium && make && make install &&
+  cd ..
+- export PKG_CONFIG_PATH=$HOME/installed_libsodium/lib/pkgconfig:$PKG_CONFIG_PATH
+- export LD_LIBRARY_PATH=$HOME/installed_libsodium/lib:$LD_LIBRARY_PATH
 script:
 - cargo build --verbose
 - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,28 +5,11 @@ rust:
 - nightly
 sudo: false
 install:
-- wget https://github.com/jedisct1/libsodium/releases/download/1.0.8/libsodium-1.0.8.tar.gz
-- tar xvfz libsodium-1.0.8.tar.gz
-- cd libsodium-1.0.8 && ./configure --prefix=$HOME/installed_libsodium && make && make install &&
-  cd ..
-- export PKG_CONFIG_PATH=$HOME/installed_libsodium/lib/pkgconfig:$PKG_CONFIG_PATH
-- export LD_LIBRARY_PATH=$HOME/installed_libsodium/lib:$LD_LIBRARY_PATH
+- wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.12.tar.gz
+- tar xvfz libsodium-1.0.12.tar.gz
+- cd libsodium-1.0.12
+- ./configure && make && make install
+- sudo ldconfig /usr/local/lib
 script:
 - cargo build --verbose
 - cargo test --verbose
-- if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test --verbose --no-default-features; fi
-- cargo test --verbose --no-default-features --features std
-- cargo doc
-after_script:
-- cd target/doc
-- git init
-- git config user.name "Travis CI"
-- git config user.email "dnaq@users.noreply.github.com"
-- echo "<meta http-equiv=refresh content=0;url=sodiumoxide/index.html>" > index.html
-- git add .
-- git commit -m "Deploy to GitHub Pages"
-- git push --force --quiet "https://${GH_TOKEN}@${GH_REF}" master:gh-pages > /dev/null 2>&1
-env:
-  global:
-    - GH_REF: github.com/dnaq/sodiumoxide.git
-    - secure: LFhOKKRNMdfsU4bUKLi+9ly5l0mrvnL9rS0M33aEyvCoeTiptuHsOCoSxZMk4iH5dA3IGQX+q6BjQlB5o/W4svSeOFfTvvXQ7QgqIoWqO0a9kAstVDZFTFM7xGMbI9jrihH4mHeT4dZdN779Mbnhg3tynbNapB+0ewA+cz3Wb5s=

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ version = "0.0.14"
 [dependencies]
 libc = "0.2"
 libsodium-sys = { version = "0.0.14", path = "libsodium-sys" }
-serde = { version="1", optional = true }
+serde = { version="^1", optional = true }
 
 [dev-dependencies]
-serde = "1"
-serde_json = "1"
-rustc-serialize = "0.3"
-rmp-serde = "0.13"
+serde = "^1"
+serde_json = "^1"
+rustc-serialize = "^0.3"
+rmp-serde = "^0.13"
 
 [features]
 benchmarks = []

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 sodiumoxide
 ===========
 
-[![Build Status](https://travis-ci.org/dnaq/sodiumoxide.svg?branch=master)](https://travis-ci.org/dnaq/sodiumoxide)
+[![Build Status](https://travis-ci.org/chritchens/sodiumoxide.svg?branch=master)](https://travis-ci.org/chritchens/sodiumoxide)
 
 > [NaCl](http://nacl.cr.yp.to) (pronounced "salt") is a new easy-to-use high-speed software library for network communication, encryption, decryption, signatures, etc. NaCl's goal is to provide all of the core operations needed to build higher-level cryptographic tools.
 > Of course, other libraries already exist for these core operations. NaCl advances the state of the art by improving security, by improving usability, and by improving speed.
@@ -32,9 +32,6 @@ Documentation will be generated in target/doc/...
 
 Most documentation is taken from NaCl, with minor modification where the API
 differs between the C and Rust versions.
-
-Documentation for the latest build can be found at
-[gh-pages](https://dnaq.github.io/sodiumoxide).
 
 Optional features
 -----------------

--- a/libsodium-sys/src/crypto_box_curve25519xsalsa20poly1305.rs
+++ b/libsodium-sys/src/crypto_box_curve25519xsalsa20poly1305.rs
@@ -13,6 +13,11 @@ pub const crypto_box_curve25519xsalsa20poly1305_MACBYTES: usize =
 
 
 extern {
+    pub fn crypto_box_curve25519xsalsa20poly1305_seed_keypair(
+        pk: *mut [u8; crypto_box_PUBLICKEYBYTES],
+        sk: *mut [u8; crypto_box_SECRETKEYBYTES],
+        seed: *const [u8; crypto_box_SEEDBYTES])
+        -> c_int;
     pub fn crypto_box_curve25519xsalsa20poly1305_keypair(
         pk: *mut [u8; crypto_box_curve25519xsalsa20poly1305_PUBLICKEYBYTES],
         sk: *mut [u8; crypto_box_curve25519xsalsa20poly1305_SECRETKEYBYTES])


### PR DESCRIPTION
It would be handy to be able to generate box key pairs by seed.Generating keys from seeds allows building key derivation functions also in the context of authenticated encryption.

The functionality is already in libsodium, and seed constants have already been added in libsodium-sys.