### PR TITLE
Hide secret values in Debug output

### DIFF
--- a/src/newtype_macros.rs
+++ b/src/newtype_macros.rs
@@ -134,12 +134,6 @@ macro_rules! newtype_traits (($newtype:ident, $len:expr) => (
             b.index(_index)
         }
     }
-    impl ::std::fmt::Debug for $newtype  {
-        fn fmt(&self,
-               formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-            write!(formatter, "{}({:?})", stringify!($newtype), &self[..])
-        }
-    }
     ));
 
 macro_rules! public_newtype_traits (($newtype:ident) => (
@@ -226,6 +220,13 @@ macro_rules! new_type {
                 memzero(v);
             }
         }
+        impl ::std::fmt::Debug for $name {
+            fn fmt(&self,
+                   formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                // Hide secrets from debug output.
+                write!(formatter, "{}(****)", stringify!($name))
+            }
+        }
         );
     ( $(#[$meta:meta])*
       public $name:ident($bytes:expr);
@@ -239,6 +240,12 @@ macro_rules! new_type {
         public_newtype_traits!($name);
         impl $name {
             newtype_from_slice!($name, $bytes);
+        }
+        impl ::std::fmt::Debug for $name {
+            fn fmt(&self,
+                   formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                write!(formatter, "{}({:?})", stringify!($name), &self[..])
+            }
         }
         );
     ( $(#[$meta:meta])*
@@ -280,6 +287,12 @@ macro_rules! new_type {
                 increment_le(r);
             }
 
+        }
+        impl ::std::fmt::Debug for $name {
+            fn fmt(&self,
+                   formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                write!(formatter, "{}({:?})", stringify!($name), &self[..])
+            }
         }
         );
 }


### PR DESCRIPTION
Hello! I noticed that `format!("{:?}", pk)` dumps the raw byte values even for `secret` newtypes. Seems safer to obscure those; what do you think?