### PR TITLE
Build libsodium from sources

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libsodium-sys/libsodium"]
+	path = libsodium-sys/libsodium
+	url = https://github.com/jedisct1/libsodium

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,6 @@ rust:
 - beta
 - nightly
 sudo: false
-install:
-- wget https://github.com/jedisct1/libsodium/releases/download/1.0.8/libsodium-1.0.8.tar.gz
-- tar xvfz libsodium-1.0.8.tar.gz
-- cd libsodium-1.0.8 && ./configure --prefix=$HOME/installed_libsodium && make && make install &&
-  cd ..
-- export PKG_CONFIG_PATH=$HOME/installed_libsodium/lib/pkgconfig:$PKG_CONFIG_PATH
-- export LD_LIBRARY_PATH=$HOME/installed_libsodium/lib:$LD_LIBRARY_PATH
 script:
 - cargo build --verbose
 - cargo test --verbose

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -1,0 +1,17 @@
+# Updating
+
+## Updating libsodium-sys/libsodium submodule
+
+The `libsodium-sys/libsodium` submodule is tracking the latest released version
+of `libsodium`. When new version is released, the submodule needs to be updated.
+
+This can be done with following set of commands. This example updates libsodium
+submodule into `1.0.14` tag of `libsodium` repository.
+
+1. `git submodule update --init`
+2. `cd libsodium-sys/libsodium`
+3. `git fetch`
+4. `git checkout 1.0.14`
+5. `git commit -m "Update to libsodium 1.0.14" libsodium-sys/libsodium/`
+
+Then Git push, etc. as usual.

--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -1,22 +1,75 @@
-use std::env;
 extern crate pkg_config;
 
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
 fn main() {
-
-    if let Ok(lib_dir) = env::var("SODIUM_LIB_DIR") {
-
-        println!("cargo:rustc-link-search=native={}", lib_dir);
-
-        let mode = match env::var_os("SODIUM_STATIC") {
-            Some(_) => "static",
-            None => "dylib",
-        };
-        println!("cargo:rustc-link-lib={0}=sodium", mode);
-
-    } else {
-
-        pkg_config::find_library("libsodium").unwrap();
-
+    // Use already existing libsodium install if pkgconfig can find one
+    match pkg_config::find_library("libsodium") {
+        Ok(_) => return,
+        Err(e) => {
+            println!(
+                "Couldn't find libsodium from pkgconfig ({:?}), compiling it from source...",
+                e
+            )
+        }
     }
 
+    // Fall back to compiling libsodium from sources
+    if !Path::new("libsodium/.git").exists() {
+        Command::new("git")
+            .args(&["submodule", "update", "--init"])
+            .status()
+            .expect("git submodule update");
+    }
+
+    // Directory to install libsodium into
+    let target_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR env variable"));
+
+    // Directory pointing to libsodium sources
+    let libsodium_dir = {
+        let cwd = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR env variable");
+        PathBuf::from(cwd).join("libsodium")
+    };
+
+    // Directory used while building libsodium
+    let build_dir = {
+        let dir = target_dir.join("libsodium_build");
+        std::fs::create_dir_all(&dir).expect("create_dir_all");
+        dir
+    };
+
+    Command::new("autogen.sh")
+        .current_dir(&libsodium_dir)
+        .status()
+        .expect("autogen.sh");
+
+    Command::new(libsodium_dir.join("configure"))
+        .current_dir(&build_dir)
+        .arg(format!("--prefix={}", target_dir.display()))
+        .args(&["--enable-static", "--disable-shared"])
+        .status().expect("configure");
+
+    Command::new("make")
+        .current_dir(&build_dir)
+        .status()
+        .expect("make");
+
+    Command::new("make")
+        .current_dir(&build_dir)
+        .arg("check")
+        .status()
+        .expect("make check");
+
+    Command::new("make")
+        .current_dir(&build_dir)
+        .arg("install")
+        .status()
+        .expect("make install");
+
+    println!("cargo:root={}", target_dir.display());
+    println!("cargo:rustc-link-lib=static=sodium");
+    println!("cargo:include={}/include", target_dir.display());
+    println!("cargo:rustc-link-search=native={}/lib", target_dir.display());
 }


### PR DESCRIPTION
This pull request modifies the `libsodium-sys`'s `build.rs` to do the following:

1. Try if pkgconfig can find libsodium and use that if found.
2. Get libsodium using Git (this PR uses libsodium tag 1.0.12), compile it and link `libsodium-sys` against it (static linking).

In the future, when new libsodium version is released, the git submodule needs to be updated to point into new version.

This PR also drops support for environment variables `SODIUM_LIB_DIR` and `SODIUM_STATIC`. However, these are easy to add back if so needed.