### PR TITLE
rerun if env change 

### DIFF
--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -3,6 +3,8 @@ extern crate pkg_config;
 
 fn main() {
 
+    println!("cargo:rerun-if-env-changed=SODIUM_LIB_DIR");
+    println!("cargo:rerun-if-env-changed=SODIUM_STATIC");
     if let Ok(lib_dir) = env::var("SODIUM_LIB_DIR") {
 
         println!("cargo:rustc-link-search=native={}", lib_dir);


### PR DESCRIPTION
rerun when env change, or cargo will cache the result of `build.rs`, for detail, [here](http://doc.crates.io/build-script.html).

if we set the env variables wrong the first time, the build process will fail, we change the env variables and rebuild, the new env variables will not work because cargo will cache the result of build.rs, set `rerun-if-env-changed=VAR` will force the build.rs to rerun.