### PR TITLE
Add crypto_kdf functions to libsodium-sys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ rust:
 - nightly
 sudo: false
 install:
-- wget https://github.com/jedisct1/libsodium/releases/download/1.0.8/libsodium-1.0.8.tar.gz
-- tar xvfz libsodium-1.0.8.tar.gz
-- cd libsodium-1.0.8 && ./configure --prefix=$HOME/installed_libsodium && make && make install &&
+- wget https://github.com/jedisct1/libsodium/releases/download/1.0.12/libsodium-1.0.12.tar.gz
+- tar xvfz libsodium-1.0.12.tar.gz
+- cd libsodium-1.0.12 && ./configure --prefix=$HOME/installed_libsodium && make && make install &&
   cd ..
 - export PKG_CONFIG_PATH=$HOME/installed_libsodium/lib/pkgconfig:$PKG_CONFIG_PATH
 - export LD_LIBRARY_PATH=$HOME/installed_libsodium/lib:$LD_LIBRARY_PATH

--- a/libsodium-sys/lib.rs
+++ b/libsodium-sys/lib.rs
@@ -1,7 +1,7 @@
 #![allow(non_upper_case_globals)]
 
 extern crate libc;
-use libc::{c_void, c_int, c_ulonglong, c_char, size_t};
+use libc::{c_void, c_int, c_ulonglong, c_char, size_t, uint64_t};
 
 include!("src/core.rs");
 
@@ -26,6 +26,9 @@ include!("src/crypto_generichash_blake2b.rs");
 include!("src/crypto_hash.rs");
 include!("src/crypto_hash_sha256.rs");
 include!("src/crypto_hash_sha512.rs");
+
+include!("src/crypto_kdf.rs");
+include!("src/crypto_kdf_blake2b.rs");
 
 include!("src/crypto_onetimeauth.rs");
 include!("src/crypto_onetimeauth_poly1305.rs");

--- a/libsodium-sys/src/crypto_kdf.rs
+++ b/libsodium-sys/src/crypto_kdf.rs
@@ -1,0 +1,73 @@
+// crypto_kdf.h
+
+pub const crypto_kdf_BYTES_MIN: usize = crypto_kdf_blake2b_BYTES_MIN;
+pub const crypto_kdf_BYTES_MAX: usize = crypto_kdf_blake2b_BYTES_MAX;
+pub const crypto_kdf_CONTEXTBYTES: usize = crypto_kdf_blake2b_CONTEXTBYTES;
+pub const crypto_kdf_KEYBYTES: usize = crypto_kdf_blake2b_KEYBYTES;
+pub const crypto_kdf_PRIMITIVE: &'static str = "blake2b";
+
+extern {
+    pub fn crypto_kdf_bytes_min() -> size_t;
+    pub fn crypto_kdf_bytes_max() -> size_t;
+    pub fn crypto_kdf_contextbytes() -> size_t;
+    pub fn crypto_kdf_keybytes() -> size_t;
+    pub fn crypto_kdf_primitive() -> *const c_char;
+
+    pub fn crypto_kdf_derive_from_key(
+        subkey: *mut u8,
+        subkey_len: size_t,
+        subkey_id: uint64_t,
+        ctx: *const [u8; crypto_kdf_CONTEXTBYTES],
+        key: *const [u8; crypto_kdf_KEYBYTES])
+        -> c_int;
+}
+
+#[test]
+fn test_crypto_kdf_bytes_min() {
+    assert_eq!(unsafe { crypto_kdf_bytes_min() as usize },
+                        crypto_kdf_BYTES_MIN)
+}
+
+#[test]
+fn test_crypto_kdf_bytes_max() {
+    assert_eq!(unsafe { crypto_kdf_bytes_max() as usize },
+                        crypto_kdf_BYTES_MAX)
+}
+
+#[test]
+fn test_crypto_kdf_contextbytes() {
+    assert_eq!(unsafe { crypto_kdf_contextbytes() as usize },
+                        crypto_kdf_CONTEXTBYTES)
+}
+
+#[test]
+fn test_crypto_kdf_keybytes() {
+    assert_eq!(unsafe { crypto_kdf_keybytes() as usize },
+                        crypto_kdf_KEYBYTES)
+}
+
+#[test]
+fn test_crypto_kdf_primitive() {
+    unsafe {
+        let s = crypto_kdf_primitive();
+        let s = std::ffi::CStr::from_ptr(s).to_bytes();
+        assert_eq!(s, crypto_kdf_PRIMITIVE.as_bytes());
+    }
+}
+
+#[test]
+fn test_crypto_kdf_derive_from_key() {
+    let mut subkey = [0u8; 32];
+    let key = [207, 248, 208, 158, 90, 30, 63, 85, 104, 123, 203, 93, 129, 163, 140, 191, 174, 127, 178, 201, 155, 186, 237, 109, 171, 50, 188, 116, 155, 105, 247, 85];
+
+    assert_eq!(unsafe {
+        crypto_kdf_derive_from_key(
+            subkey.as_mut_ptr(),
+            subkey.len(),
+            0,
+            b"kdf_test",
+            &key)
+    }, 0);
+
+    assert_eq!(subkey, [177, 166, 148, 67, 88, 130, 103, 19, 144, 61, 16, 223, 114, 206, 92, 204, 71, 77, 16, 139, 142, 109, 88, 30, 162, 125, 22, 80, 76, 97, 27, 244]);
+}

--- a/libsodium-sys/src/crypto_kdf_blake2b.rs
+++ b/libsodium-sys/src/crypto_kdf_blake2b.rs
@@ -1,0 +1,62 @@
+// crypto_kdf_blake2b.h
+
+pub const crypto_kdf_blake2b_BYTES_MIN: usize = 16;
+pub const crypto_kdf_blake2b_BYTES_MAX: usize = 64;
+pub const crypto_kdf_blake2b_CONTEXTBYTES: usize = 8;
+pub const crypto_kdf_blake2b_KEYBYTES: usize = 32;
+
+extern {
+    pub fn crypto_kdf_blake2b_bytes_min() -> size_t;
+    pub fn crypto_kdf_blake2b_bytes_max() -> size_t;
+    pub fn crypto_kdf_blake2b_contextbytes() -> size_t;
+    pub fn crypto_kdf_blake2b_keybytes() -> size_t;
+
+    pub fn crypto_kdf_blake2b_derive_from_key(
+        subkey: *mut u8,
+        subkey_len: size_t,
+        subkey_id: uint64_t,
+        ctx: *const [u8; crypto_kdf_blake2b_CONTEXTBYTES],
+        key: *const [u8; crypto_kdf_blake2b_KEYBYTES])
+        -> c_int;
+}
+
+#[test]
+fn test_crypto_kdf_blake2b_bytes_min() {
+    assert_eq!(unsafe { crypto_kdf_blake2b_bytes_min() as usize },
+                        crypto_kdf_blake2b_BYTES_MIN)
+}
+
+#[test]
+fn test_crypto_kdf_blake2b_bytes_max() {
+    assert_eq!(unsafe { crypto_kdf_blake2b_bytes_max() as usize },
+                        crypto_kdf_blake2b_BYTES_MAX)
+}
+
+#[test]
+fn test_crypto_kdf_blake2b_contextbytes() {
+    assert_eq!(unsafe { crypto_kdf_blake2b_contextbytes() as usize },
+                        crypto_kdf_blake2b_CONTEXTBYTES)
+}
+
+#[test]
+fn test_crypto_kdf_blake2b_keybytes() {
+    assert_eq!(unsafe { crypto_kdf_blake2b_keybytes() as usize },
+                        crypto_kdf_blake2b_KEYBYTES)
+}
+
+#[test]
+fn test_crypto_kdf_blake2b_derive_from_key() {
+    let mut subkey = [0u8; 32];
+    let key = [207, 248, 208, 158, 90, 30, 63, 85, 104, 123, 203, 93, 129, 163, 140, 191, 174, 127, 178, 201, 155, 186, 237, 109, 171, 50, 188, 116, 155, 105, 247, 85];
+
+    assert_eq!(unsafe {
+        crypto_kdf_blake2b_derive_from_key(
+            subkey.as_mut_ptr(),
+            subkey.len(),
+            0,
+            b"kdf_test",
+            &key)
+    }, 0);
+
+    assert_eq!(subkey, [177, 166, 148, 67, 88, 130, 103, 19, 144, 61, 16, 223, 114, 206, 92, 204, 71, 77, 16, 139, 142, 109, 88, 30, 162, 125, 22, 80, 76, 97, 27, 244]);
+}


### PR DESCRIPTION
Add access to key derivation functions (crypto_kdf_*) which were introduced in libsodium 1.0.12.