### PR TITLE
Add HashState for multi-parts (Init-Update-Final) hash computation.

### DIFF
--- a/src/crypto/hash/mod.rs
+++ b/src/crypto/hash/mod.rs
@@ -35,6 +35,11 @@
 //!
 //! let data_to_hash = b"some data";
 //! let digest = hash::hash(data_to_hash);
+//!
+//! let mut hash_state = hash::HashState::new();
+//! hash_state.update(b"some ");
+//! hash_state.update(b"data!");
+//! let digest = hash_state.finish();
 //! ```
 pub use self::sha512::*;
 #[macro_use]

--- a/src/crypto/hash/sha256.rs
+++ b/src/crypto/hash/sha256.rs
@@ -5,9 +5,18 @@
 //! However, for the moment, there do not appear to be alternatives that
 //! inspire satisfactory levels of confidence. One can hope that NIST's
 //! SHA-3 competition will improve the situation.
-use ffi::{crypto_hash_sha256, crypto_hash_sha256_BYTES};
+use ffi::{crypto_hash_sha256,
+          crypto_hash_sha256_state,
+          crypto_hash_sha256_init,
+          crypto_hash_sha256_update,
+          crypto_hash_sha256_final,
+          crypto_hash_sha256_BYTES};
 
 hash_module!(crypto_hash_sha256,
+             crypto_hash_sha256_state,
+             crypto_hash_sha256_init,
+             crypto_hash_sha256_update,
+             crypto_hash_sha256_final,
              crypto_hash_sha256_BYTES,
              64);
 
@@ -82,5 +91,38 @@ mod test {
     #[test]
     fn test_vectors_nist_long() {
         test_nist_vector("testvectors/SHA256LongMsg.rsp");
+    }
+
+    #[test]
+    fn test_hash_state_empty() {
+        // hash of empty string
+        let h_expected = [0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14,
+                          0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24,
+                          0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c,
+                          0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55];
+        let hash_state = HashState::new();
+        let Digest(h) = hash_state.finish();
+        assert!(h == h_expected);
+    }
+
+    #[test]
+    fn test_hash_state_multi_parts() {
+        // The quick brown fox jumps over the lazy dog
+        let x = [0x54, 0x68, 0x65, 0x20, 0x71, 0x75, 0x69, 0x63,
+                 0x6b, 0x20, 0x62, 0x72, 0x6f, 0x77, 0x6e, 0x20,
+                 0x66, 0x6f, 0x78, 0x20, 0x6a, 0x75, 0x6d, 0x70,
+                 0x73, 0x20, 0x6f, 0x76, 0x65, 0x72, 0x20, 0x74,
+                 0x68, 0x65, 0x20, 0x6c, 0x61, 0x7a, 0x79, 0x20,
+                 0x64, 0x6f, 0x67];
+        let h_expected = [0xd7, 0xa8, 0xfb, 0xb3, 0x07, 0xd7, 0x80, 0x94,
+                          0x69, 0xca, 0x9a, 0xbc, 0xb0, 0x08, 0x2e, 0x4f,
+                          0x8d, 0x56, 0x51, 0xe4, 0x6d, 0x3c, 0xdb, 0x76,
+                          0x2d, 0x02, 0xd0, 0xbf, 0x37, 0xc9, 0xe5, 0x92];
+        let mut hash_state = HashState::new();
+        for chunk in x.chunks(3) {
+            hash_state.update(chunk);
+        }
+        let Digest(h) = hash_state.finish();
+        assert!(h == h_expected);
     }
 }

--- a/src/crypto/hash/sha512.rs
+++ b/src/crypto/hash/sha512.rs
@@ -5,9 +5,18 @@
 //! However, for the moment, there do not appear to be alternatives that
 //! inspire satisfactory levels of confidence. One can hope that NIST's
 //! SHA-3 competition will improve the situation.
-use ffi::{crypto_hash_sha512, crypto_hash_sha512_BYTES};
+use ffi::{crypto_hash_sha512,
+          crypto_hash_sha512_state,
+          crypto_hash_sha512_init,
+          crypto_hash_sha512_update,
+          crypto_hash_sha512_final,
+          crypto_hash_sha512_BYTES};
 
 hash_module!(crypto_hash_sha512,
+             crypto_hash_sha512_state,
+             crypto_hash_sha512_init,
+             crypto_hash_sha512_update,
+             crypto_hash_sha512_final,
              crypto_hash_sha512_BYTES,
              128);
 
@@ -70,5 +79,26 @@ mod test {
     #[test]
     fn test_vectors_nist_long() {
         test_nist_vector("testvectors/SHA512LongMsg.rsp");
+    }
+
+    #[test]
+    fn test_hash_state_multi_parts() {
+        // corresponding to tests/hash.c, tests/hash2.cpp,
+        // tests/hash3.c and tests/hash4.cpp from NaCl
+        let x = [0x74, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67, 0xa];
+        let h_expected = [0x24, 0xf9, 0x50, 0xaa, 0xc7, 0xb9, 0xea, 0x9b
+                         ,0x3c, 0xb7, 0x28, 0x22, 0x8a, 0x0c, 0x82, 0xb6
+                         ,0x7c, 0x39, 0xe9, 0x6b, 0x4b, 0x34, 0x47, 0x98
+                         ,0x87, 0x0d, 0x5d, 0xae, 0xe9, 0x3e, 0x3a, 0xe5
+                         ,0x93, 0x1b, 0xaa, 0xe8, 0xc7, 0xca, 0xcf, 0xea
+                         ,0x4b, 0x62, 0x94, 0x52, 0xc3, 0x80, 0x26, 0xa8
+                         ,0x1d, 0x13, 0x8b, 0xc7, 0xaa, 0xd1, 0xaf, 0x3e
+                         ,0xf7, 0xbf, 0xd5, 0xec, 0x64, 0x6d, 0x6c, 0x28];
+        let mut hash_state = HashState::new();
+        for chunk in x.chunks(3) {
+            hash_state.update(chunk);
+        }
+        let Digest(h) = hash_state.finish();
+        assert!(&h[..] == &h_expected[..]);
     }
 }


### PR DESCRIPTION
Fix #119. It is similar to #158 but rebased to master.