### PR TITLE
Add `minmal` feature analogue to libsodium's `--enable-minimal`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,5 @@ rmp-serde = "0.13"
 [features]
 benchmarks = []
 std = []
-default = ["serde", "std"]
+minimal = []
+default = ["serde", "std", "minimal"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Several [optional features](http://doc.crates.io/manifest.html#usage-in-end-prod
   keys, authentication tags, etc. using the
   [serde library](https://crates.io/crates/serde).
 
+* `minimal` (default: **enabled**). Creates a minimal build, without deprecated functions.
+  Needs to be enabled when linking against libsodium, built with `--enable-minimal`.
+
 * `benchmarks` (default: **disabled**). Compile benchmark tests. Requires a
   nightly build of Rust.
 

--- a/src/crypto/stream/mod.rs
+++ b/src/crypto/stream/mod.rs
@@ -89,6 +89,7 @@ pub use self::xsalsa20::*;
 #[macro_use]
 mod stream_macros;
 pub mod xsalsa20;
+#[cfg(not(feature = "minimal"))]
 pub mod aes128ctr;
 pub mod salsa208;
 pub mod salsa2012;


### PR DESCRIPTION
`sodiumoxide` needs to be built with the `minmal` feature enabled when linking against libsodium, built with the `--enable-minimal` flag.

I don't like defining a feature that removes functionality but in this case I wanted it to be analogous with the libsodium flag.