### PR TITLE
Padding and API improvements

### DIFF
--- a/libsodium-sys/src/utils.rs
+++ b/libsodium-sys/src/utils.rs
@@ -15,4 +15,14 @@ extern {
     pub fn sodium_mprotect_noaccess(ptr: *const c_void) -> c_int;
     pub fn sodium_mprotect_readonly(ptr: *const c_void) -> c_int;
     pub fn sodium_mprotect_readwrite(ptr: *const c_void) -> c_int;
+
+    pub fn sodium_pad(padded_buflen_p: *mut usize,
+                  buf: *mut u8,
+                  unpadded_buflen: usize,
+                  blocksize: usize,
+                  max_buflen: usize) -> c_int;
+    pub fn sodium_unpad(unpadded_buflen_p: *mut usize,
+                    buf: *const u8,
+                    padded_buflen: usize,
+                    blocksize: usize) -> c_int;
 }

--- a/libsodium-sys/src/utils.rs
+++ b/libsodium-sys/src/utils.rs
@@ -17,12 +17,12 @@ extern {
     pub fn sodium_mprotect_readwrite(ptr: *const c_void) -> c_int;
 
     pub fn sodium_pad(padded_buflen_p: *mut usize,
-                  buf: *mut u8,
-                  unpadded_buflen: usize,
-                  blocksize: usize,
-                  max_buflen: usize) -> c_int;
+                      buf: *mut u8,
+                      unpadded_buflen: usize,
+                      blocksize: usize,
+                      max_buflen: usize) -> c_int;
     pub fn sodium_unpad(unpadded_buflen_p: *mut usize,
-                    buf: *const u8,
-                    padded_buflen: usize,
-                    blocksize: usize) -> c_int;
+                        buf: *const u8,
+                        padded_buflen: usize,
+                        blocksize: usize) -> c_int;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,10 +84,12 @@ mod prelude {
 /// functions (`gen_key`, `gen_keypair`, `gen_nonce`, `randombytes`, `randombytes_into`)
 /// thread-safe
 ///
-/// `init()` returns `false` if initialization failed.
-pub fn init() -> bool {
-    unsafe {
-        ffi::sodium_init() != -1
+/// `init()` returns `Ok` if initialization succeeded and `Err` if it failed.
+pub fn init() -> Result<(), ()> {
+    if unsafe { ffi::sodium_init() } >= 0 {
+        Ok(())
+    } else {
+        Err(())
     }
 }
 


### PR DESCRIPTION
This pull request comprises of 2 changes:

1. It changes the return type of `sodiumoxide::init()` from `bool` to `Result`. Since thread safety of many libsodium functions, as well as the initialization of a cryptographically-secure PRNG depends on (or rather, is indicated by) the success of `sodium_init()`, ignoring the return value of `sodiumoxide::init()` can lead to security bugs related to threading and low-quality randomness. In order to issue a compiler warning when a user ignores the return value of this function, it now returns a `Result` — which also happens to match its semantics better, since it _is_ a success/failure value.
    I do realize that this is a breaking change, but it's probably a very minor one — chances are, depending projects invoke `sodiumoxide::init()` from only one place anyway, and changing a Boolean test to an `if let Ok(_)` or an `expect()` isn't a huge effort.
    The library doesn't have a stable semantic version, so that shouldn't be a problem, either.

2. The pull request also adds safe bindings to the `sodium_pad()` and `sodium_unpad()` functions in the form of `utils::pad()` and `utils::unpad()`.
    The `pad()` function consumes its argument in a `Vec<u8>`, since it unconditionally needs to grow the buffer. So, if the user already has a vector, this way we can avoid copying it by taking it by value rather than accepting a slice.
    `unpad()`, however, does accept and return a slice, since it does not need to allocate, and if one wants to modify e.g. a `Vec<u8>` in-place to remove padding from its end, they can just use `my_owned_vec.truncate(unpadded_slice.len());` instead.
