### PR TITLE
Add link to sodium installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ as easy to use.
 Dependencies
 ------------
 
-[Sodium](https://github.com/jedisct1/libsodium)
+[Sodium](https://github.com/jedisct1/libsodium) ([installation](https://download.libsodium.org/doc/installation/index.html))
 
 Building
 --------


### PR DESCRIPTION
It's probably not abnormal for packages to have outside dependencies, but this was my first time encountering one. I think it'd be helpful to include a link to installation instructions for the dependency, so that's what this small patch implements.